### PR TITLE
Correct time zone in county files

### DIFF
--- a/dsgrid_project/datasets/modeled/comstock/dimensions/conus_2022-comstock_geography_county_fips.csv
+++ b/dsgrid_project/datasets/modeled/comstock/dimensions/conus_2022-comstock_geography_county_fips.csv
@@ -89,21 +89,21 @@ G0202400,Southeast Fairbanks County,AK,AlaskaPrevailing
 G0202610,Valdez-Cordova County,AK,AlaskaPrevailing
 G0202700,Wade Hampton County,AK,AlaskaPrevailing
 G0202900,Yukon-Koyukuk County,AK,AlaskaPrevailing
-G0400010,Apache County,AZ,MountainStandard
-G0400030,Cochise County,AZ,MountainStandard
-G0400050,Coconino County,AZ,MountainStandard
-G0400070,Gila County,AZ,MountainStandard
-G0400090,Graham County,AZ,MountainStandard
-G0400110,Greenlee County,AZ,MountainStandard
-G0400120,La Paz County,AZ,MountainStandard
-G0400130,Maricopa County,AZ,MountainStandard
-G0400150,Mohave County,AZ,MountainStandard
+G0400010,Apache County,AZ,USArizona
+G0400030,Cochise County,AZ,USArizona
+G0400050,Coconino County,AZ,USArizona
+G0400070,Gila County,AZ,USArizona
+G0400090,Graham County,AZ,USArizona
+G0400110,Greenlee County,AZ,USArizona
+G0400120,La Paz County,AZ,USArizona
+G0400130,Maricopa County,AZ,USArizona
+G0400150,Mohave County,AZ,USArizona
 G0400170,Navajo County,AZ,MountainPrevailing
-G0400190,Pima County,AZ,MountainStandard
-G0400210,Pinal County,AZ,MountainStandard
-G0400230,Santa Cruz County,AZ,MountainStandard
-G0400250,Yavapai County,AZ,MountainStandard
-G0400270,Yuma County,AZ,MountainStandard
+G0400190,Pima County,AZ,USArizona
+G0400210,Pinal County,AZ,USArizona
+G0400230,Santa Cruz County,AZ,USArizona
+G0400250,Yavapai County,AZ,USArizona
+G0400270,Yuma County,AZ,USArizona
 G0500010,Arkansas County,AR,CentralPrevailing
 G0500030,Ashley County,AR,CentralPrevailing
 G0500050,Baxter County,AR,CentralPrevailing
@@ -2004,7 +2004,7 @@ G3800450,LaMoure County,ND,CentralPrevailing
 G3800470,Logan County,ND,CentralPrevailing
 G3800490,McHenry County,ND,CentralPrevailing
 G3800510,McIntosh County,ND,CentralPrevailing
-G3800530,McKenzie County,ND,CentralPrevailing
+G3800530,McKenzie County,ND,MountainPrevailing
 G3800550,McLean County,ND,CentralPrevailing
 G3800570,Mercer County,ND,CentralPrevailing
 G3800590,Morton County,ND,CentralPrevailing
@@ -2352,63 +2352,63 @@ G4500890,Williamsburg County,SC,EasternPrevailing
 G4500910,York County,SC,EasternPrevailing
 G4600030,Aurora County,SD,CentralPrevailing
 G4600050,Beadle County,SD,CentralPrevailing
-G4600070,Bennett County,SD,EasternPrevailing
+G4600070,Bennett County,SD,MountainPrevailing
 G4600090,Bon Homme County,SD,CentralPrevailing
 G4600110,Brookings County,SD,CentralPrevailing
 G4600130,Brown County,SD,CentralPrevailing
 G4600150,Brule County,SD,CentralPrevailing
 G4600170,Buffalo County,SD,CentralPrevailing
-G4600190,Butte County,SD,EasternPrevailing
+G4600190,Butte County,SD,MountainPrevailing
 G4600210,Campbell County,SD,CentralPrevailing
 G4600230,Charles Mix County,SD,CentralPrevailing
 G4600250,Clark County,SD,CentralPrevailing
 G4600270,Clay County,SD,CentralPrevailing
 G4600290,Codington County,SD,CentralPrevailing
-G4600310,Corson County,SD,EasternPrevailing
-G4600330,Custer County,SD,EasternPrevailing
+G4600310,Corson County,SD,MountainPrevailing
+G4600330,Custer County,SD,MountainPrevailing
 G4600350,Davison County,SD,CentralPrevailing
 G4600370,Day County,SD,CentralPrevailing
 G4600390,Deuel County,SD,CentralPrevailing
-G4600410,Dewey County,SD,EasternPrevailing
+G4600410,Dewey County,SD,MountainPrevailing
 G4600430,Douglas County,SD,CentralPrevailing
 G4600450,Edmunds County,SD,CentralPrevailing
-G4600470,Fall River County,SD,EasternPrevailing
+G4600470,Fall River County,SD,MountainPrevailing
 G4600490,Faulk County,SD,CentralPrevailing
 G4600510,Grant County,SD,CentralPrevailing
 G4600530,Gregory County,SD,CentralPrevailing
-G4600550,Haakon County,SD,EasternPrevailing
+G4600550,Haakon County,SD,MountainPrevailing
 G4600570,Hamlin County,SD,CentralPrevailing
 G4600590,Hand County,SD,CentralPrevailing
 G4600610,Hanson County,SD,CentralPrevailing
-G4600630,Harding County,SD,EasternPrevailing
+G4600630,Harding County,SD,MountainPrevailing
 G4600650,Hughes County,SD,CentralPrevailing
 G4600670,Hutchinson County,SD,CentralPrevailing
 G4600690,Hyde County,SD,CentralPrevailing
-G4600710,Jackson County,SD,EasternPrevailing
+G4600710,Jackson County,SD,MountainPrevailing
 G4600730,Jerauld County,SD,CentralPrevailing
 G4600750,Jones County,SD,CentralPrevailing
 G4600770,Kingsbury County,SD,CentralPrevailing
 G4600790,Lake County,SD,CentralPrevailing
-G4600810,Lawrence County,SD,EasternPrevailing
+G4600810,Lawrence County,SD,MountainPrevailing
 G4600830,Lincoln County,SD,CentralPrevailing
 G4600850,Lyman County,SD,CentralPrevailing
 G4600870,McCook County,SD,CentralPrevailing
 G4600890,McPherson County,SD,CentralPrevailing
 G4600910,Marshall County,SD,CentralPrevailing
-G4600930,Meade County,SD,EasternPrevailing
+G4600930,Meade County,SD,MountainPrevailing
 G4600950,Mellette County,SD,CentralPrevailing
 G4600970,Miner County,SD,CentralPrevailing
 G4600990,Minnehaha County,SD,CentralPrevailing
 G4601010,Moody County,SD,CentralPrevailing
-G4601020,Oglala Lakota County,SD,CentralPrevailing
-G4601030,Pennington County,SD,EasternPrevailing
-G4601050,Perkins County,SD,EasternPrevailing
+G4601020,Oglala Lakota County,SD,MountainPrevailing
+G4601030,Pennington County,SD,MountainPrevailing
+G4601050,Perkins County,SD,MountainPrevailing
 G4601070,Potter County,SD,CentralPrevailing
 G4601090,Roberts County,SD,CentralPrevailing
 G4601110,Sanborn County,SD,CentralPrevailing
 G4601130,Shannon County,SD,MountainPrevailing
 G4601150,Spink County,SD,CentralPrevailing
-G4601170,Stanley County,SD,CentralPrevailing
+G4601170,Stanley County,SD,MountainPrevailing
 G4601190,Sully County,SD,CentralPrevailing
 G4601210,Todd County,SD,CentralPrevailing
 G4601230,Tripp County,SD,CentralPrevailing

--- a/dsgrid_project/datasets/modeled/resstock/dimensions/conus_2022-resstock_geography_county_fips.csv
+++ b/dsgrid_project/datasets/modeled/resstock/dimensions/conus_2022-resstock_geography_county_fips.csv
@@ -66,21 +66,21 @@ G0101270,Walker County,AL,CentralPrevailing
 G0101290,Washington County,AL,CentralPrevailing
 G0101310,Wilcox County,AL,CentralPrevailing
 G0101330,Winston County,AL,CentralPrevailing
-G0400010,Apache County,AZ,MountainStandard
-G0400030,Cochise County,AZ,MountainStandard
-G0400050,Coconino County,AZ,MountainStandard
-G0400070,Gila County,AZ,MountainStandard
-G0400090,Graham County,AZ,MountainStandard
-G0400110,Greenlee County,AZ,MountainStandard
-G0400120,La Paz County,AZ,MountainStandard
-G0400130,Maricopa County,AZ,MountainStandard
-G0400150,Mohave County,AZ,MountainStandard
+G0400010,Apache County,AZ,USArizona
+G0400030,Cochise County,AZ,USArizona
+G0400050,Coconino County,AZ,USArizona
+G0400070,Gila County,AZ,USArizona
+G0400090,Graham County,AZ,USArizona
+G0400110,Greenlee County,AZ,USArizona
+G0400120,La Paz County,AZ,USArizona
+G0400130,Maricopa County,AZ,USArizona
+G0400150,Mohave County,AZ,USArizona
 G0400170,Navajo County,AZ,MountainPrevailing
-G0400190,Pima County,AZ,MountainStandard
-G0400210,Pinal County,AZ,MountainStandard
-G0400230,Santa Cruz County,AZ,MountainStandard
-G0400250,Yavapai County,AZ,MountainStandard
-G0400270,Yuma County,AZ,MountainStandard
+G0400190,Pima County,AZ,USArizona
+G0400210,Pinal County,AZ,USArizona
+G0400230,Santa Cruz County,AZ,USArizona
+G0400250,Yavapai County,AZ,USArizona
+G0400270,Yuma County,AZ,USArizona
 G0500010,Arkansas County,AR,CentralPrevailing
 G0500030,Ashley County,AR,CentralPrevailing
 G0500050,Baxter County,AR,CentralPrevailing
@@ -1981,7 +1981,7 @@ G3800450,LaMoure County,ND,CentralPrevailing
 G3800470,Logan County,ND,CentralPrevailing
 G3800490,McHenry County,ND,CentralPrevailing
 G3800510,McIntosh County,ND,CentralPrevailing
-G3800530,McKenzie County,ND,CentralPrevailing
+G3800530,McKenzie County,ND,MountainPrevailing
 G3800550,McLean County,ND,CentralPrevailing
 G3800570,Mercer County,ND,CentralPrevailing
 G3800590,Morton County,ND,CentralPrevailing
@@ -2329,62 +2329,62 @@ G4500890,Williamsburg County,SC,EasternPrevailing
 G4500910,York County,SC,EasternPrevailing
 G4600030,Aurora County,SD,CentralPrevailing
 G4600050,Beadle County,SD,CentralPrevailing
-G4600070,Bennett County,SD,EasternPrevailing
+G4600070,Bennett County,SD,MountainPrevailing
 G4600090,Bon Homme County,SD,CentralPrevailing
 G4600110,Brookings County,SD,CentralPrevailing
 G4600130,Brown County,SD,CentralPrevailing
 G4600150,Brule County,SD,CentralPrevailing
 G4600170,Buffalo County,SD,CentralPrevailing
-G4600190,Butte County,SD,EasternPrevailing
+G4600190,Butte County,SD,MountainPrevailing
 G4600210,Campbell County,SD,CentralPrevailing
 G4600230,Charles Mix County,SD,CentralPrevailing
 G4600250,Clark County,SD,CentralPrevailing
 G4600270,Clay County,SD,CentralPrevailing
 G4600290,Codington County,SD,CentralPrevailing
-G4600310,Corson County,SD,EasternPrevailing
-G4600330,Custer County,SD,EasternPrevailing
+G4600310,Corson County,SD,MountainPrevailing
+G4600330,Custer County,SD,MountainPrevailing
 G4600350,Davison County,SD,CentralPrevailing
 G4600370,Day County,SD,CentralPrevailing
 G4600390,Deuel County,SD,CentralPrevailing
-G4600410,Dewey County,SD,EasternPrevailing
+G4600410,Dewey County,SD,MountainPrevailing
 G4600430,Douglas County,SD,CentralPrevailing
 G4600450,Edmunds County,SD,CentralPrevailing
-G4600470,Fall River County,SD,EasternPrevailing
+G4600470,Fall River County,SD,MountainPrevailing
 G4600490,Faulk County,SD,CentralPrevailing
 G4600510,Grant County,SD,CentralPrevailing
 G4600530,Gregory County,SD,CentralPrevailing
-G4600550,Haakon County,SD,EasternPrevailing
+G4600550,Haakon County,SD,MountainPrevailing
 G4600570,Hamlin County,SD,CentralPrevailing
 G4600590,Hand County,SD,CentralPrevailing
 G4600610,Hanson County,SD,CentralPrevailing
-G4600630,Harding County,SD,EasternPrevailing
+G4600630,Harding County,SD,MountainPrevailing
 G4600650,Hughes County,SD,CentralPrevailing
 G4600670,Hutchinson County,SD,CentralPrevailing
 G4600690,Hyde County,SD,CentralPrevailing
-G4600710,Jackson County,SD,EasternPrevailing
+G4600710,Jackson County,SD,MountainPrevailing
 G4600730,Jerauld County,SD,CentralPrevailing
 G4600750,Jones County,SD,CentralPrevailing
 G4600770,Kingsbury County,SD,CentralPrevailing
 G4600790,Lake County,SD,CentralPrevailing
-G4600810,Lawrence County,SD,EasternPrevailing
+G4600810,Lawrence County,SD,MountainPrevailing
 G4600830,Lincoln County,SD,CentralPrevailing
 G4600850,Lyman County,SD,CentralPrevailing
 G4600870,McCook County,SD,CentralPrevailing
 G4600890,McPherson County,SD,CentralPrevailing
 G4600910,Marshall County,SD,CentralPrevailing
-G4600930,Meade County,SD,EasternPrevailing
+G4600930,Meade County,SD,MountainPrevailing
 G4600950,Mellette County,SD,CentralPrevailing
 G4600970,Miner County,SD,CentralPrevailing
 G4600990,Minnehaha County,SD,CentralPrevailing
 G4601010,Moody County,SD,CentralPrevailing
-G4601020,Oglala Lakota County,SD,CentralPrevailing
-G4601030,Pennington County,SD,EasternPrevailing
-G4601050,Perkins County,SD,EasternPrevailing
+G4601020,Oglala Lakota County,SD,MountainPrevailing
+G4601030,Pennington County,SD,MountainPrevailing
+G4601050,Perkins County,SD,MountainPrevailing
 G4601070,Potter County,SD,CentralPrevailing
 G4601090,Roberts County,SD,CentralPrevailing
 G4601110,Sanborn County,SD,CentralPrevailing
 G4601150,Spink County,SD,CentralPrevailing
-G4601170,Stanley County,SD,CentralPrevailing
+G4601170,Stanley County,SD,MountainPrevailing
 G4601190,Sully County,SD,CentralPrevailing
 G4601210,Todd County,SD,CentralPrevailing
 G4601230,Tripp County,SD,CentralPrevailing

--- a/dsgrid_project/dimensions/counties.csv
+++ b/dsgrid_project/dimensions/counties.csv
@@ -1,291 +1,291 @@
 id,name,state,time_zone
-1001,Autauga,AL,CentralPrevailing
-1003,Baldwin,AL,CentralPrevailing
-1005,Barbour,AL,CentralPrevailing
-1007,Bibb,AL,CentralPrevailing
-1009,Blount,AL,CentralPrevailing
-1011,Bullock,AL,CentralPrevailing
-1013,Butler,AL,CentralPrevailing
-1015,Calhoun,AL,CentralPrevailing
-1017,Chambers,AL,CentralPrevailing
-1019,Cherokee,AL,CentralPrevailing
-1021,Chilton,AL,CentralPrevailing
-1023,Choctaw,AL,CentralPrevailing
-1025,Clarke,AL,CentralPrevailing
-1027,Clay,AL,CentralPrevailing
-1029,Cleburne,AL,CentralPrevailing
-1031,Coffee,AL,CentralPrevailing
-1033,Colbert,AL,CentralPrevailing
-1035,Conecuh,AL,CentralPrevailing
-1037,Coosa,AL,CentralPrevailing
-1039,Covington,AL,CentralPrevailing
-1041,Crenshaw,AL,CentralPrevailing
-1043,Cullman,AL,CentralPrevailing
-1045,Dale,AL,CentralPrevailing
-1047,Dallas,AL,CentralPrevailing
-1049,DeKalb,AL,CentralPrevailing
-1051,Elmore,AL,CentralPrevailing
-1053,Escambia,AL,CentralPrevailing
-1055,Etowah,AL,CentralPrevailing
-1057,Fayette,AL,CentralPrevailing
-1059,Franklin,AL,CentralPrevailing
-1061,Geneva,AL,CentralPrevailing
-1063,Greene,AL,CentralPrevailing
-1065,Hale,AL,CentralPrevailing
-1067,Henry,AL,CentralPrevailing
-1069,Houston,AL,CentralPrevailing
-1071,Jackson,AL,CentralPrevailing
-1073,Jefferson,AL,CentralPrevailing
-1075,Lamar,AL,CentralPrevailing
-1077,Lauderdale,AL,CentralPrevailing
-1079,Lawrence,AL,CentralPrevailing
-1081,Lee,AL,CentralPrevailing
-1083,Limestone,AL,CentralPrevailing
-1085,Lowndes,AL,CentralPrevailing
-1087,Macon,AL,CentralPrevailing
-1089,Madison,AL,CentralPrevailing
-1091,Marengo,AL,CentralPrevailing
-1093,Marion,AL,CentralPrevailing
-1095,Marshall,AL,CentralPrevailing
-1097,Mobile,AL,CentralPrevailing
-1099,Monroe,AL,CentralPrevailing
-1101,Montgomery,AL,CentralPrevailing
-1103,Morgan,AL,CentralPrevailing
-1105,Perry,AL,CentralPrevailing
-1107,Pickens,AL,CentralPrevailing
-1109,Pike,AL,CentralPrevailing
-1111,Randolph,AL,CentralPrevailing
-1113,Russell,AL,CentralPrevailing
-1115,St. Clair,AL,CentralPrevailing
-1117,Shelby,AL,CentralPrevailing
-1119,Sumter,AL,CentralPrevailing
-1121,Talladega,AL,CentralPrevailing
-1123,Tallapoosa,AL,CentralPrevailing
-1125,Tuscaloosa,AL,CentralPrevailing
-1127,Walker,AL,CentralPrevailing
-1129,Washington,AL,CentralPrevailing
-1131,Wilcox,AL,CentralPrevailing
-1133,Winston,AL,CentralPrevailing
-4001,Apache,AZ,MountainStandard
-4003,Cochise,AZ,MountainStandard
-4005,Coconino,AZ,MountainStandard
-4007,Gila,AZ,MountainStandard
-4009,Graham,AZ,MountainStandard
-4011,Greenlee,AZ,MountainStandard
-4012,La Paz,AZ,MountainStandard
-4013,Maricopa,AZ,MountainStandard
-4015,Mohave,AZ,MountainStandard
-4017,Navajo,AZ,MountainPrevailing
-4019,Pima,AZ,MountainStandard
-4021,Pinal,AZ,MountainStandard
-4023,Santa Cruz,AZ,MountainStandard
-4025,Yavapai,AZ,MountainStandard
-4027,Yuma,AZ,MountainStandard
-5001,Arkansas,AR,CentralPrevailing
-5003,Ashley,AR,CentralPrevailing
-5005,Baxter,AR,CentralPrevailing
-5007,Benton,AR,CentralPrevailing
-5009,Boone,AR,CentralPrevailing
-5011,Bradley,AR,CentralPrevailing
-5013,Calhoun,AR,CentralPrevailing
-5015,Carroll,AR,CentralPrevailing
-5017,Chicot,AR,CentralPrevailing
-5019,Clark,AR,CentralPrevailing
-5021,Clay,AR,CentralPrevailing
-5023,Cleburne,AR,CentralPrevailing
-5025,Cleveland,AR,CentralPrevailing
-5027,Columbia,AR,CentralPrevailing
-5029,Conway,AR,CentralPrevailing
-5031,Craighead,AR,CentralPrevailing
-5033,Crawford,AR,CentralPrevailing
-5035,Crittenden,AR,CentralPrevailing
-5037,Cross,AR,CentralPrevailing
-5039,Dallas,AR,CentralPrevailing
-5041,Desha,AR,CentralPrevailing
-5043,Drew,AR,CentralPrevailing
-5045,Faulkner,AR,CentralPrevailing
-5047,Franklin,AR,CentralPrevailing
-5049,Fulton,AR,CentralPrevailing
-5051,Garland,AR,CentralPrevailing
-5053,Grant,AR,CentralPrevailing
-5055,Greene,AR,CentralPrevailing
-5057,Hempstead,AR,CentralPrevailing
-5059,Hot Spring,AR,CentralPrevailing
-5061,Howard,AR,CentralPrevailing
-5063,Independence,AR,CentralPrevailing
-5065,Izard,AR,CentralPrevailing
-5067,Jackson,AR,CentralPrevailing
-5069,Jefferson,AR,CentralPrevailing
-5071,Johnson,AR,CentralPrevailing
-5073,Lafayette,AR,CentralPrevailing
-5075,Lawrence,AR,CentralPrevailing
-5077,Lee,AR,CentralPrevailing
-5079,Lincoln,AR,CentralPrevailing
-5081,Little River,AR,CentralPrevailing
-5083,Logan,AR,CentralPrevailing
-5085,Lonoke,AR,CentralPrevailing
-5087,Madison,AR,CentralPrevailing
-5089,Marion,AR,CentralPrevailing
-5091,Miller,AR,CentralPrevailing
-5093,Mississippi,AR,CentralPrevailing
-5095,Monroe,AR,CentralPrevailing
-5097,Montgomery,AR,CentralPrevailing
-5099,Nevada,AR,CentralPrevailing
-5101,Newton,AR,CentralPrevailing
-5103,Ouachita,AR,CentralPrevailing
-5105,Perry,AR,CentralPrevailing
-5107,Phillips,AR,CentralPrevailing
-5109,Pike,AR,CentralPrevailing
-5111,Poinsett,AR,CentralPrevailing
-5113,Polk,AR,CentralPrevailing
-5115,Pope,AR,CentralPrevailing
-5117,Prairie,AR,CentralPrevailing
-5119,Pulaski,AR,CentralPrevailing
-5121,Randolph,AR,CentralPrevailing
-5123,St. Francis,AR,CentralPrevailing
-5125,Saline,AR,CentralPrevailing
-5127,Scott,AR,CentralPrevailing
-5129,Searcy,AR,CentralPrevailing
-5131,Sebastian,AR,CentralPrevailing
-5133,Sevier,AR,CentralPrevailing
-5135,Sharp,AR,CentralPrevailing
-5137,Stone,AR,CentralPrevailing
-5139,Union,AR,CentralPrevailing
-5141,Van Buren,AR,CentralPrevailing
-5143,Washington,AR,CentralPrevailing
-5145,White,AR,CentralPrevailing
-5147,Woodruff,AR,CentralPrevailing
-5149,Yell,AR,CentralPrevailing
-6001,Alameda,CA,PacificPrevailing
-6003,Alpine,CA,PacificPrevailing
-6005,Amador,CA,PacificPrevailing
-6007,Butte,CA,PacificPrevailing
-6009,Calaveras,CA,PacificPrevailing
-6011,Colusa,CA,PacificPrevailing
-6013,Contra Costa,CA,PacificPrevailing
-6015,Del Norte,CA,PacificPrevailing
-6017,El Dorado,CA,PacificPrevailing
-6019,Fresno,CA,PacificPrevailing
-6021,Glenn,CA,PacificPrevailing
-6023,Humboldt,CA,PacificPrevailing
-6025,Imperial,CA,PacificPrevailing
-6027,Inyo,CA,PacificPrevailing
-6029,Kern,CA,PacificPrevailing
-6031,Kings,CA,PacificPrevailing
-6033,Lake,CA,PacificPrevailing
-6035,Lassen,CA,PacificPrevailing
-6037,Los Angeles,CA,PacificPrevailing
-6039,Madera,CA,PacificPrevailing
-6041,Marin,CA,PacificPrevailing
-6043,Mariposa,CA,PacificPrevailing
-6045,Mendocino,CA,PacificPrevailing
-6047,Merced,CA,PacificPrevailing
-6049,Modoc,CA,PacificPrevailing
-6051,Mono,CA,PacificPrevailing
-6053,Monterey,CA,PacificPrevailing
-6055,Napa,CA,PacificPrevailing
-6057,Nevada,CA,PacificPrevailing
-6059,Orange,CA,PacificPrevailing
-6061,Placer,CA,PacificPrevailing
-6063,Plumas,CA,PacificPrevailing
-6065,Riverside,CA,PacificPrevailing
-6067,Sacramento,CA,PacificPrevailing
-6069,San Benito,CA,PacificPrevailing
-6071,San Bernardino,CA,PacificPrevailing
-6073,San Diego,CA,PacificPrevailing
-6075,San Francisco,CA,PacificPrevailing
-6077,San Joaquin,CA,PacificPrevailing
-6079,San Luis Obispo,CA,PacificPrevailing
-6081,San Mateo,CA,PacificPrevailing
-6083,Santa Barbara,CA,PacificPrevailing
-6085,Santa Clara,CA,PacificPrevailing
-6087,Santa Cruz,CA,PacificPrevailing
-6089,Shasta,CA,PacificPrevailing
-6091,Sierra,CA,PacificPrevailing
-6093,Siskiyou,CA,PacificPrevailing
-6095,Solano,CA,PacificPrevailing
-6097,Sonoma,CA,PacificPrevailing
-6099,Stanislaus,CA,PacificPrevailing
-6101,Sutter,CA,PacificPrevailing
-6103,Tehama,CA,PacificPrevailing
-6105,Trinity,CA,PacificPrevailing
-6107,Tulare,CA,PacificPrevailing
-6109,Tuolumne,CA,PacificPrevailing
-6111,Ventura,CA,PacificPrevailing
-6113,Yolo,CA,PacificPrevailing
-6115,Yuba,CA,PacificPrevailing
-8001,Adams,CO,MountainPrevailing
-8003,Alamosa,CO,MountainPrevailing
-8005,Arapahoe,CO,MountainPrevailing
-8007,Archuleta,CO,MountainPrevailing
-8009,Baca,CO,MountainPrevailing
-8011,Bent,CO,MountainPrevailing
-8013,Boulder,CO,MountainPrevailing
-8014,Broomfield,CO,MountainPrevailing
-8015,Chaffee,CO,MountainPrevailing
-8017,Cheyenne,CO,MountainPrevailing
-8019,Clear Creek,CO,MountainPrevailing
-8021,Conejos,CO,MountainPrevailing
-8023,Costilla,CO,MountainPrevailing
-8025,Crowley,CO,MountainPrevailing
-8027,Custer,CO,MountainPrevailing
-8029,Delta,CO,MountainPrevailing
-8031,Denver,CO,MountainPrevailing
-8033,Dolores,CO,MountainPrevailing
-8035,Douglas,CO,MountainPrevailing
-8037,Eagle,CO,MountainPrevailing
-8039,Elbert,CO,MountainPrevailing
-8041,El Paso,CO,MountainPrevailing
-8043,Fremont,CO,MountainPrevailing
-8045,Garfield,CO,MountainPrevailing
-8047,Gilpin,CO,MountainPrevailing
-8049,Grand,CO,MountainPrevailing
-8051,Gunnison,CO,MountainPrevailing
-8053,Hinsdale,CO,MountainPrevailing
-8055,Huerfano,CO,MountainPrevailing
-8057,Jackson,CO,MountainPrevailing
-8059,Jefferson,CO,MountainPrevailing
-8061,Kiowa,CO,MountainPrevailing
-8063,Kit Carson,CO,MountainPrevailing
-8065,Lake,CO,MountainPrevailing
-8067,La Plata,CO,MountainPrevailing
-8069,Larimer,CO,MountainPrevailing
-8071,Las Animas,CO,MountainPrevailing
-8073,Lincoln,CO,MountainPrevailing
-8075,Logan,CO,MountainPrevailing
-8077,Mesa,CO,MountainPrevailing
-8079,Mineral,CO,MountainPrevailing
-8081,Moffat,CO,MountainPrevailing
-8083,Montezuma,CO,MountainPrevailing
-8085,Montrose,CO,MountainPrevailing
-8087,Morgan,CO,MountainPrevailing
-8089,Otero,CO,MountainPrevailing
-8091,Ouray,CO,MountainPrevailing
-8093,Park,CO,MountainPrevailing
-8095,Phillips,CO,MountainPrevailing
-8097,Pitkin,CO,MountainPrevailing
-8099,Prowers,CO,MountainPrevailing
-8101,Pueblo,CO,MountainPrevailing
-8103,Rio Blanco,CO,MountainPrevailing
-8105,Rio Grande,CO,MountainPrevailing
-8107,Routt,CO,MountainPrevailing
-8109,Saguache,CO,MountainPrevailing
-8111,San Juan,CO,MountainPrevailing
-8113,San Miguel,CO,MountainPrevailing
-8115,Sedgwick,CO,MountainPrevailing
-8117,Summit,CO,MountainPrevailing
-8119,Teller,CO,MountainPrevailing
-8121,Washington,CO,MountainPrevailing
-8123,Weld,CO,MountainPrevailing
-8125,Yuma,CO,MountainPrevailing
-9001,Fairfield,CT,EasternPrevailing
-9003,Hartford,CT,EasternPrevailing
-9005,Litchfield,CT,EasternPrevailing
-9007,Middlesex,CT,EasternPrevailing
-9009,New Haven,CT,EasternPrevailing
-9011,New London,CT,EasternPrevailing
-9013,Tolland,CT,EasternPrevailing
-9015,Windham,CT,EasternPrevailing
+01001,Autauga,AL,CentralPrevailing
+01003,Baldwin,AL,CentralPrevailing
+01005,Barbour,AL,CentralPrevailing
+01007,Bibb,AL,CentralPrevailing
+01009,Blount,AL,CentralPrevailing
+01011,Bullock,AL,CentralPrevailing
+01013,Butler,AL,CentralPrevailing
+01015,Calhoun,AL,CentralPrevailing
+01017,Chambers,AL,CentralPrevailing
+01019,Cherokee,AL,CentralPrevailing
+01021,Chilton,AL,CentralPrevailing
+01023,Choctaw,AL,CentralPrevailing
+01025,Clarke,AL,CentralPrevailing
+01027,Clay,AL,CentralPrevailing
+01029,Cleburne,AL,CentralPrevailing
+01031,Coffee,AL,CentralPrevailing
+01033,Colbert,AL,CentralPrevailing
+01035,Conecuh,AL,CentralPrevailing
+01037,Coosa,AL,CentralPrevailing
+01039,Covington,AL,CentralPrevailing
+01041,Crenshaw,AL,CentralPrevailing
+01043,Cullman,AL,CentralPrevailing
+01045,Dale,AL,CentralPrevailing
+01047,Dallas,AL,CentralPrevailing
+01049,DeKalb,AL,CentralPrevailing
+01051,Elmore,AL,CentralPrevailing
+01053,Escambia,AL,CentralPrevailing
+01055,Etowah,AL,CentralPrevailing
+01057,Fayette,AL,CentralPrevailing
+01059,Franklin,AL,CentralPrevailing
+01061,Geneva,AL,CentralPrevailing
+01063,Greene,AL,CentralPrevailing
+01065,Hale,AL,CentralPrevailing
+01067,Henry,AL,CentralPrevailing
+01069,Houston,AL,CentralPrevailing
+01071,Jackson,AL,CentralPrevailing
+01073,Jefferson,AL,CentralPrevailing
+01075,Lamar,AL,CentralPrevailing
+01077,Lauderdale,AL,CentralPrevailing
+01079,Lawrence,AL,CentralPrevailing
+01081,Lee,AL,CentralPrevailing
+01083,Limestone,AL,CentralPrevailing
+01085,Lowndes,AL,CentralPrevailing
+01087,Macon,AL,CentralPrevailing
+01089,Madison,AL,CentralPrevailing
+01091,Marengo,AL,CentralPrevailing
+01093,Marion,AL,CentralPrevailing
+01095,Marshall,AL,CentralPrevailing
+01097,Mobile,AL,CentralPrevailing
+01099,Monroe,AL,CentralPrevailing
+01101,Montgomery,AL,CentralPrevailing
+01103,Morgan,AL,CentralPrevailing
+01105,Perry,AL,CentralPrevailing
+01107,Pickens,AL,CentralPrevailing
+01109,Pike,AL,CentralPrevailing
+01111,Randolph,AL,CentralPrevailing
+01113,Russell,AL,CentralPrevailing
+01115,St. Clair,AL,CentralPrevailing
+01117,Shelby,AL,CentralPrevailing
+01119,Sumter,AL,CentralPrevailing
+01121,Talladega,AL,CentralPrevailing
+01123,Tallapoosa,AL,CentralPrevailing
+01125,Tuscaloosa,AL,CentralPrevailing
+01127,Walker,AL,CentralPrevailing
+01129,Washington,AL,CentralPrevailing
+01131,Wilcox,AL,CentralPrevailing
+01133,Winston,AL,CentralPrevailing
+04001,Apache,AZ,USArizona
+04003,Cochise,AZ,USArizona
+04005,Coconino,AZ,USArizona
+04007,Gila,AZ,USArizona
+04009,Graham,AZ,USArizona
+04011,Greenlee,AZ,USArizona
+04012,La Paz,AZ,USArizona
+04013,Maricopa,AZ,USArizona
+04015,Mohave,AZ,USArizona
+04017,Navajo,AZ,MountainPrevailing
+04019,Pima,AZ,USArizona
+04021,Pinal,AZ,USArizona
+04023,Santa Cruz,AZ,USArizona
+04025,Yavapai,AZ,USArizona
+04027,Yuma,AZ,USArizona
+05001,Arkansas,AR,CentralPrevailing
+05003,Ashley,AR,CentralPrevailing
+05005,Baxter,AR,CentralPrevailing
+05007,Benton,AR,CentralPrevailing
+05009,Boone,AR,CentralPrevailing
+05011,Bradley,AR,CentralPrevailing
+05013,Calhoun,AR,CentralPrevailing
+05015,Carroll,AR,CentralPrevailing
+05017,Chicot,AR,CentralPrevailing
+05019,Clark,AR,CentralPrevailing
+05021,Clay,AR,CentralPrevailing
+05023,Cleburne,AR,CentralPrevailing
+05025,Cleveland,AR,CentralPrevailing
+05027,Columbia,AR,CentralPrevailing
+05029,Conway,AR,CentralPrevailing
+05031,Craighead,AR,CentralPrevailing
+05033,Crawford,AR,CentralPrevailing
+05035,Crittenden,AR,CentralPrevailing
+05037,Cross,AR,CentralPrevailing
+05039,Dallas,AR,CentralPrevailing
+05041,Desha,AR,CentralPrevailing
+05043,Drew,AR,CentralPrevailing
+05045,Faulkner,AR,CentralPrevailing
+05047,Franklin,AR,CentralPrevailing
+05049,Fulton,AR,CentralPrevailing
+05051,Garland,AR,CentralPrevailing
+05053,Grant,AR,CentralPrevailing
+05055,Greene,AR,CentralPrevailing
+05057,Hempstead,AR,CentralPrevailing
+05059,Hot Spring,AR,CentralPrevailing
+05061,Howard,AR,CentralPrevailing
+05063,Independence,AR,CentralPrevailing
+05065,Izard,AR,CentralPrevailing
+05067,Jackson,AR,CentralPrevailing
+05069,Jefferson,AR,CentralPrevailing
+05071,Johnson,AR,CentralPrevailing
+05073,Lafayette,AR,CentralPrevailing
+05075,Lawrence,AR,CentralPrevailing
+05077,Lee,AR,CentralPrevailing
+05079,Lincoln,AR,CentralPrevailing
+05081,Little River,AR,CentralPrevailing
+05083,Logan,AR,CentralPrevailing
+05085,Lonoke,AR,CentralPrevailing
+05087,Madison,AR,CentralPrevailing
+05089,Marion,AR,CentralPrevailing
+05091,Miller,AR,CentralPrevailing
+05093,Mississippi,AR,CentralPrevailing
+05095,Monroe,AR,CentralPrevailing
+05097,Montgomery,AR,CentralPrevailing
+05099,Nevada,AR,CentralPrevailing
+05101,Newton,AR,CentralPrevailing
+05103,Ouachita,AR,CentralPrevailing
+05105,Perry,AR,CentralPrevailing
+05107,Phillips,AR,CentralPrevailing
+05109,Pike,AR,CentralPrevailing
+05111,Poinsett,AR,CentralPrevailing
+05113,Polk,AR,CentralPrevailing
+05115,Pope,AR,CentralPrevailing
+05117,Prairie,AR,CentralPrevailing
+05119,Pulaski,AR,CentralPrevailing
+05121,Randolph,AR,CentralPrevailing
+05123,St. Francis,AR,CentralPrevailing
+05125,Saline,AR,CentralPrevailing
+05127,Scott,AR,CentralPrevailing
+05129,Searcy,AR,CentralPrevailing
+05131,Sebastian,AR,CentralPrevailing
+05133,Sevier,AR,CentralPrevailing
+05135,Sharp,AR,CentralPrevailing
+05137,Stone,AR,CentralPrevailing
+05139,Union,AR,CentralPrevailing
+05141,Van Buren,AR,CentralPrevailing
+05143,Washington,AR,CentralPrevailing
+05145,White,AR,CentralPrevailing
+05147,Woodruff,AR,CentralPrevailing
+05149,Yell,AR,CentralPrevailing
+06001,Alameda,CA,PacificPrevailing
+06003,Alpine,CA,PacificPrevailing
+06005,Amador,CA,PacificPrevailing
+06007,Butte,CA,PacificPrevailing
+06009,Calaveras,CA,PacificPrevailing
+06011,Colusa,CA,PacificPrevailing
+06013,Contra Costa,CA,PacificPrevailing
+06015,Del Norte,CA,PacificPrevailing
+06017,El Dorado,CA,PacificPrevailing
+06019,Fresno,CA,PacificPrevailing
+06021,Glenn,CA,PacificPrevailing
+06023,Humboldt,CA,PacificPrevailing
+06025,Imperial,CA,PacificPrevailing
+06027,Inyo,CA,PacificPrevailing
+06029,Kern,CA,PacificPrevailing
+06031,Kings,CA,PacificPrevailing
+06033,Lake,CA,PacificPrevailing
+06035,Lassen,CA,PacificPrevailing
+06037,Los Angeles,CA,PacificPrevailing
+06039,Madera,CA,PacificPrevailing
+06041,Marin,CA,PacificPrevailing
+06043,Mariposa,CA,PacificPrevailing
+06045,Mendocino,CA,PacificPrevailing
+06047,Merced,CA,PacificPrevailing
+06049,Modoc,CA,PacificPrevailing
+06051,Mono,CA,PacificPrevailing
+06053,Monterey,CA,PacificPrevailing
+06055,Napa,CA,PacificPrevailing
+06057,Nevada,CA,PacificPrevailing
+06059,Orange,CA,PacificPrevailing
+06061,Placer,CA,PacificPrevailing
+06063,Plumas,CA,PacificPrevailing
+06065,Riverside,CA,PacificPrevailing
+06067,Sacramento,CA,PacificPrevailing
+06069,San Benito,CA,PacificPrevailing
+06071,San Bernardino,CA,PacificPrevailing
+06073,San Diego,CA,PacificPrevailing
+06075,San Francisco,CA,PacificPrevailing
+06077,San Joaquin,CA,PacificPrevailing
+06079,San Luis Obispo,CA,PacificPrevailing
+06081,San Mateo,CA,PacificPrevailing
+06083,Santa Barbara,CA,PacificPrevailing
+06085,Santa Clara,CA,PacificPrevailing
+06087,Santa Cruz,CA,PacificPrevailing
+06089,Shasta,CA,PacificPrevailing
+06091,Sierra,CA,PacificPrevailing
+06093,Siskiyou,CA,PacificPrevailing
+06095,Solano,CA,PacificPrevailing
+06097,Sonoma,CA,PacificPrevailing
+06099,Stanislaus,CA,PacificPrevailing
+06101,Sutter,CA,PacificPrevailing
+06103,Tehama,CA,PacificPrevailing
+06105,Trinity,CA,PacificPrevailing
+06107,Tulare,CA,PacificPrevailing
+06109,Tuolumne,CA,PacificPrevailing
+06111,Ventura,CA,PacificPrevailing
+06113,Yolo,CA,PacificPrevailing
+06115,Yuba,CA,PacificPrevailing
+08001,Adams,CO,MountainPrevailing
+08003,Alamosa,CO,MountainPrevailing
+08005,Arapahoe,CO,MountainPrevailing
+08007,Archuleta,CO,MountainPrevailing
+08009,Baca,CO,MountainPrevailing
+08011,Bent,CO,MountainPrevailing
+08013,Boulder,CO,MountainPrevailing
+08014,Broomfield,CO,MountainPrevailing
+08015,Chaffee,CO,MountainPrevailing
+08017,Cheyenne,CO,MountainPrevailing
+08019,Clear Creek,CO,MountainPrevailing
+08021,Conejos,CO,MountainPrevailing
+08023,Costilla,CO,MountainPrevailing
+08025,Crowley,CO,MountainPrevailing
+08027,Custer,CO,MountainPrevailing
+08029,Delta,CO,MountainPrevailing
+08031,Denver,CO,MountainPrevailing
+08033,Dolores,CO,MountainPrevailing
+08035,Douglas,CO,MountainPrevailing
+08037,Eagle,CO,MountainPrevailing
+08039,Elbert,CO,MountainPrevailing
+08041,El Paso,CO,MountainPrevailing
+08043,Fremont,CO,MountainPrevailing
+08045,Garfield,CO,MountainPrevailing
+08047,Gilpin,CO,MountainPrevailing
+08049,Grand,CO,MountainPrevailing
+08051,Gunnison,CO,MountainPrevailing
+08053,Hinsdale,CO,MountainPrevailing
+08055,Huerfano,CO,MountainPrevailing
+08057,Jackson,CO,MountainPrevailing
+08059,Jefferson,CO,MountainPrevailing
+08061,Kiowa,CO,MountainPrevailing
+08063,Kit Carson,CO,MountainPrevailing
+08065,Lake,CO,MountainPrevailing
+08067,La Plata,CO,MountainPrevailing
+08069,Larimer,CO,MountainPrevailing
+08071,Las Animas,CO,MountainPrevailing
+08073,Lincoln,CO,MountainPrevailing
+08075,Logan,CO,MountainPrevailing
+08077,Mesa,CO,MountainPrevailing
+08079,Mineral,CO,MountainPrevailing
+08081,Moffat,CO,MountainPrevailing
+08083,Montezuma,CO,MountainPrevailing
+08085,Montrose,CO,MountainPrevailing
+08087,Morgan,CO,MountainPrevailing
+08089,Otero,CO,MountainPrevailing
+08091,Ouray,CO,MountainPrevailing
+08093,Park,CO,MountainPrevailing
+08095,Phillips,CO,MountainPrevailing
+08097,Pitkin,CO,MountainPrevailing
+08099,Prowers,CO,MountainPrevailing
+08101,Pueblo,CO,MountainPrevailing
+08103,Rio Blanco,CO,MountainPrevailing
+08105,Rio Grande,CO,MountainPrevailing
+08107,Routt,CO,MountainPrevailing
+08109,Saguache,CO,MountainPrevailing
+08111,San Juan,CO,MountainPrevailing
+08113,San Miguel,CO,MountainPrevailing
+08115,Sedgwick,CO,MountainPrevailing
+08117,Summit,CO,MountainPrevailing
+08119,Teller,CO,MountainPrevailing
+08121,Washington,CO,MountainPrevailing
+08123,Weld,CO,MountainPrevailing
+08125,Yuma,CO,MountainPrevailing
+09001,Fairfield,CT,EasternPrevailing
+09003,Hartford,CT,EasternPrevailing
+09005,Litchfield,CT,EasternPrevailing
+09007,Middlesex,CT,EasternPrevailing
+09009,New Haven,CT,EasternPrevailing
+09011,New London,CT,EasternPrevailing
+09013,Tolland,CT,EasternPrevailing
+09015,Windham,CT,EasternPrevailing
 10001,Kent,DE,EasternPrevailing
 10003,New Castle,DE,EasternPrevailing
 10005,Sussex,DE,EasternPrevailing
@@ -1981,7 +1981,7 @@ id,name,state,time_zone
 38047,Logan,ND,CentralPrevailing
 38049,McHenry,ND,CentralPrevailing
 38051,McIntosh,ND,CentralPrevailing
-38053,McKenzie,ND,CentralPrevailing
+38053,McKenzie,ND,MountainPrevailing
 38055,McLean,ND,CentralPrevailing
 38057,Mercer,ND,CentralPrevailing
 38059,Morton,ND,CentralPrevailing
@@ -2329,62 +2329,62 @@ id,name,state,time_zone
 45091,York,SC,EasternPrevailing
 46003,Aurora,SD,CentralPrevailing
 46005,Beadle,SD,CentralPrevailing
-46007,Bennett,SD,EasternPrevailing
+46007,Bennett,SD,MountainPrevailing
 46009,Bon Homme,SD,CentralPrevailing
 46011,Brookings,SD,CentralPrevailing
 46013,Brown,SD,CentralPrevailing
 46015,Brule,SD,CentralPrevailing
 46017,Buffalo,SD,CentralPrevailing
-46019,Butte,SD,EasternPrevailing
+46019,Butte,SD,MountainPrevailing
 46021,Campbell,SD,CentralPrevailing
 46023,Charles Mix,SD,CentralPrevailing
 46025,Clark,SD,CentralPrevailing
 46027,Clay,SD,CentralPrevailing
 46029,Codington,SD,CentralPrevailing
-46031,Corson,SD,EasternPrevailing
-46033,Custer,SD,EasternPrevailing
+46031,Corson,SD,MountainPrevailing
+46033,Custer,SD,MountainPrevailing
 46035,Davison,SD,CentralPrevailing
 46037,Day,SD,CentralPrevailing
 46039,Deuel,SD,CentralPrevailing
-46041,Dewey,SD,EasternPrevailing
+46041,Dewey,SD,MountainPrevailing
 46043,Douglas,SD,CentralPrevailing
 46045,Edmunds,SD,CentralPrevailing
-46047,Fall River,SD,EasternPrevailing
+46047,Fall River,SD,MountainPrevailing
 46049,Faulk,SD,CentralPrevailing
 46051,Grant,SD,CentralPrevailing
 46053,Gregory,SD,CentralPrevailing
-46055,Haakon,SD,EasternPrevailing
+46055,Haakon,SD,MountainPrevailing
 46057,Hamlin,SD,CentralPrevailing
 46059,Hand,SD,CentralPrevailing
 46061,Hanson,SD,CentralPrevailing
-46063,Harding,SD,EasternPrevailing
+46063,Harding,SD,MountainPrevailing
 46065,Hughes,SD,CentralPrevailing
 46067,Hutchinson,SD,CentralPrevailing
 46069,Hyde,SD,CentralPrevailing
-46071,Jackson,SD,EasternPrevailing
+46071,Jackson,SD,MountainPrevailing
 46073,Jerauld,SD,CentralPrevailing
 46075,Jones,SD,CentralPrevailing
 46077,Kingsbury,SD,CentralPrevailing
 46079,Lake,SD,CentralPrevailing
-46081,Lawrence,SD,EasternPrevailing
+46081,Lawrence,SD,MountainPrevailing
 46083,Lincoln,SD,CentralPrevailing
 46085,Lyman,SD,CentralPrevailing
 46087,McCook,SD,CentralPrevailing
 46089,McPherson,SD,CentralPrevailing
 46091,Marshall,SD,CentralPrevailing
-46093,Meade,SD,EasternPrevailing
+46093,Meade,SD,MountainPrevailing
 46095,Mellette,SD,CentralPrevailing
 46097,Miner,SD,CentralPrevailing
 46099,Minnehaha,SD,CentralPrevailing
 46101,Moody,SD,CentralPrevailing
-46102,Oglala Lakota,SD,CentralPrevailing
-46103,Pennington,SD,EasternPrevailing
-46105,Perkins,SD,EasternPrevailing
+46102,Oglala Lakota,SD,MountainPrevailing
+46103,Pennington,SD,MountainPrevailing
+46105,Perkins,SD,MountainPrevailing
 46107,Potter,SD,CentralPrevailing
 46109,Roberts,SD,CentralPrevailing
 46111,Sanborn,SD,CentralPrevailing
 46115,Spink,SD,CentralPrevailing
-46117,Stanley,SD,CentralPrevailing
+46117,Stanley,SD,MountainPrevailing
 46119,Sully,SD,CentralPrevailing
 46121,Todd,SD,CentralPrevailing
 46123,Tripp,SD,CentralPrevailing

--- a/dsgrid_project/dimensions/counties.csv
+++ b/dsgrid_project/dimensions/counties.csv
@@ -1,291 +1,291 @@
 id,name,state,time_zone
-01001,Autauga,AL,CentralPrevailing
-01003,Baldwin,AL,CentralPrevailing
-01005,Barbour,AL,CentralPrevailing
-01007,Bibb,AL,CentralPrevailing
-01009,Blount,AL,CentralPrevailing
-01011,Bullock,AL,CentralPrevailing
-01013,Butler,AL,CentralPrevailing
-01015,Calhoun,AL,CentralPrevailing
-01017,Chambers,AL,CentralPrevailing
-01019,Cherokee,AL,CentralPrevailing
-01021,Chilton,AL,CentralPrevailing
-01023,Choctaw,AL,CentralPrevailing
-01025,Clarke,AL,CentralPrevailing
-01027,Clay,AL,CentralPrevailing
-01029,Cleburne,AL,CentralPrevailing
-01031,Coffee,AL,CentralPrevailing
-01033,Colbert,AL,CentralPrevailing
-01035,Conecuh,AL,CentralPrevailing
-01037,Coosa,AL,CentralPrevailing
-01039,Covington,AL,CentralPrevailing
-01041,Crenshaw,AL,CentralPrevailing
-01043,Cullman,AL,CentralPrevailing
-01045,Dale,AL,CentralPrevailing
-01047,Dallas,AL,CentralPrevailing
-01049,DeKalb,AL,CentralPrevailing
-01051,Elmore,AL,CentralPrevailing
-01053,Escambia,AL,CentralPrevailing
-01055,Etowah,AL,CentralPrevailing
-01057,Fayette,AL,CentralPrevailing
-01059,Franklin,AL,CentralPrevailing
-01061,Geneva,AL,CentralPrevailing
-01063,Greene,AL,CentralPrevailing
-01065,Hale,AL,CentralPrevailing
-01067,Henry,AL,CentralPrevailing
-01069,Houston,AL,CentralPrevailing
-01071,Jackson,AL,CentralPrevailing
-01073,Jefferson,AL,CentralPrevailing
-01075,Lamar,AL,CentralPrevailing
-01077,Lauderdale,AL,CentralPrevailing
-01079,Lawrence,AL,CentralPrevailing
-01081,Lee,AL,CentralPrevailing
-01083,Limestone,AL,CentralPrevailing
-01085,Lowndes,AL,CentralPrevailing
-01087,Macon,AL,CentralPrevailing
-01089,Madison,AL,CentralPrevailing
-01091,Marengo,AL,CentralPrevailing
-01093,Marion,AL,CentralPrevailing
-01095,Marshall,AL,CentralPrevailing
-01097,Mobile,AL,CentralPrevailing
-01099,Monroe,AL,CentralPrevailing
-01101,Montgomery,AL,CentralPrevailing
-01103,Morgan,AL,CentralPrevailing
-01105,Perry,AL,CentralPrevailing
-01107,Pickens,AL,CentralPrevailing
-01109,Pike,AL,CentralPrevailing
-01111,Randolph,AL,CentralPrevailing
-01113,Russell,AL,CentralPrevailing
-01115,St. Clair,AL,CentralPrevailing
-01117,Shelby,AL,CentralPrevailing
-01119,Sumter,AL,CentralPrevailing
-01121,Talladega,AL,CentralPrevailing
-01123,Tallapoosa,AL,CentralPrevailing
-01125,Tuscaloosa,AL,CentralPrevailing
-01127,Walker,AL,CentralPrevailing
-01129,Washington,AL,CentralPrevailing
-01131,Wilcox,AL,CentralPrevailing
-01133,Winston,AL,CentralPrevailing
-04001,Apache,AZ,MountainStandard
-04003,Cochise,AZ,MountainStandard
-04005,Coconino,AZ,MountainStandard
-04007,Gila,AZ,MountainStandard
-04009,Graham,AZ,MountainStandard
-04011,Greenlee,AZ,MountainStandard
-04012,La Paz,AZ,MountainStandard
-04013,Maricopa,AZ,MountainStandard
-04015,Mohave,AZ,MountainStandard
-04017,Navajo,AZ,MountainPrevailing
-04019,Pima,AZ,MountainStandard
-04021,Pinal,AZ,MountainStandard
-04023,Santa Cruz,AZ,MountainStandard
-04025,Yavapai,AZ,MountainStandard
-04027,Yuma,AZ,MountainStandard
-05001,Arkansas,AR,CentralPrevailing
-05003,Ashley,AR,CentralPrevailing
-05005,Baxter,AR,CentralPrevailing
-05007,Benton,AR,CentralPrevailing
-05009,Boone,AR,CentralPrevailing
-05011,Bradley,AR,CentralPrevailing
-05013,Calhoun,AR,CentralPrevailing
-05015,Carroll,AR,CentralPrevailing
-05017,Chicot,AR,CentralPrevailing
-05019,Clark,AR,CentralPrevailing
-05021,Clay,AR,CentralPrevailing
-05023,Cleburne,AR,CentralPrevailing
-05025,Cleveland,AR,CentralPrevailing
-05027,Columbia,AR,CentralPrevailing
-05029,Conway,AR,CentralPrevailing
-05031,Craighead,AR,CentralPrevailing
-05033,Crawford,AR,CentralPrevailing
-05035,Crittenden,AR,CentralPrevailing
-05037,Cross,AR,CentralPrevailing
-05039,Dallas,AR,CentralPrevailing
-05041,Desha,AR,CentralPrevailing
-05043,Drew,AR,CentralPrevailing
-05045,Faulkner,AR,CentralPrevailing
-05047,Franklin,AR,CentralPrevailing
-05049,Fulton,AR,CentralPrevailing
-05051,Garland,AR,CentralPrevailing
-05053,Grant,AR,CentralPrevailing
-05055,Greene,AR,CentralPrevailing
-05057,Hempstead,AR,CentralPrevailing
-05059,Hot Spring,AR,CentralPrevailing
-05061,Howard,AR,CentralPrevailing
-05063,Independence,AR,CentralPrevailing
-05065,Izard,AR,CentralPrevailing
-05067,Jackson,AR,CentralPrevailing
-05069,Jefferson,AR,CentralPrevailing
-05071,Johnson,AR,CentralPrevailing
-05073,Lafayette,AR,CentralPrevailing
-05075,Lawrence,AR,CentralPrevailing
-05077,Lee,AR,CentralPrevailing
-05079,Lincoln,AR,CentralPrevailing
-05081,Little River,AR,CentralPrevailing
-05083,Logan,AR,CentralPrevailing
-05085,Lonoke,AR,CentralPrevailing
-05087,Madison,AR,CentralPrevailing
-05089,Marion,AR,CentralPrevailing
-05091,Miller,AR,CentralPrevailing
-05093,Mississippi,AR,CentralPrevailing
-05095,Monroe,AR,CentralPrevailing
-05097,Montgomery,AR,CentralPrevailing
-05099,Nevada,AR,CentralPrevailing
-05101,Newton,AR,CentralPrevailing
-05103,Ouachita,AR,CentralPrevailing
-05105,Perry,AR,CentralPrevailing
-05107,Phillips,AR,CentralPrevailing
-05109,Pike,AR,CentralPrevailing
-05111,Poinsett,AR,CentralPrevailing
-05113,Polk,AR,CentralPrevailing
-05115,Pope,AR,CentralPrevailing
-05117,Prairie,AR,CentralPrevailing
-05119,Pulaski,AR,CentralPrevailing
-05121,Randolph,AR,CentralPrevailing
-05123,St. Francis,AR,CentralPrevailing
-05125,Saline,AR,CentralPrevailing
-05127,Scott,AR,CentralPrevailing
-05129,Searcy,AR,CentralPrevailing
-05131,Sebastian,AR,CentralPrevailing
-05133,Sevier,AR,CentralPrevailing
-05135,Sharp,AR,CentralPrevailing
-05137,Stone,AR,CentralPrevailing
-05139,Union,AR,CentralPrevailing
-05141,Van Buren,AR,CentralPrevailing
-05143,Washington,AR,CentralPrevailing
-05145,White,AR,CentralPrevailing
-05147,Woodruff,AR,CentralPrevailing
-05149,Yell,AR,CentralPrevailing
-06001,Alameda,CA,PacificPrevailing
-06003,Alpine,CA,PacificPrevailing
-06005,Amador,CA,PacificPrevailing
-06007,Butte,CA,PacificPrevailing
-06009,Calaveras,CA,PacificPrevailing
-06011,Colusa,CA,PacificPrevailing
-06013,Contra Costa,CA,PacificPrevailing
-06015,Del Norte,CA,PacificPrevailing
-06017,El Dorado,CA,PacificPrevailing
-06019,Fresno,CA,PacificPrevailing
-06021,Glenn,CA,PacificPrevailing
-06023,Humboldt,CA,PacificPrevailing
-06025,Imperial,CA,PacificPrevailing
-06027,Inyo,CA,PacificPrevailing
-06029,Kern,CA,PacificPrevailing
-06031,Kings,CA,PacificPrevailing
-06033,Lake,CA,PacificPrevailing
-06035,Lassen,CA,PacificPrevailing
-06037,Los Angeles,CA,PacificPrevailing
-06039,Madera,CA,PacificPrevailing
-06041,Marin,CA,PacificPrevailing
-06043,Mariposa,CA,PacificPrevailing
-06045,Mendocino,CA,PacificPrevailing
-06047,Merced,CA,PacificPrevailing
-06049,Modoc,CA,PacificPrevailing
-06051,Mono,CA,PacificPrevailing
-06053,Monterey,CA,PacificPrevailing
-06055,Napa,CA,PacificPrevailing
-06057,Nevada,CA,PacificPrevailing
-06059,Orange,CA,PacificPrevailing
-06061,Placer,CA,PacificPrevailing
-06063,Plumas,CA,PacificPrevailing
-06065,Riverside,CA,PacificPrevailing
-06067,Sacramento,CA,PacificPrevailing
-06069,San Benito,CA,PacificPrevailing
-06071,San Bernardino,CA,PacificPrevailing
-06073,San Diego,CA,PacificPrevailing
-06075,San Francisco,CA,PacificPrevailing
-06077,San Joaquin,CA,PacificPrevailing
-06079,San Luis Obispo,CA,PacificPrevailing
-06081,San Mateo,CA,PacificPrevailing
-06083,Santa Barbara,CA,PacificPrevailing
-06085,Santa Clara,CA,PacificPrevailing
-06087,Santa Cruz,CA,PacificPrevailing
-06089,Shasta,CA,PacificPrevailing
-06091,Sierra,CA,PacificPrevailing
-06093,Siskiyou,CA,PacificPrevailing
-06095,Solano,CA,PacificPrevailing
-06097,Sonoma,CA,PacificPrevailing
-06099,Stanislaus,CA,PacificPrevailing
-06101,Sutter,CA,PacificPrevailing
-06103,Tehama,CA,PacificPrevailing
-06105,Trinity,CA,PacificPrevailing
-06107,Tulare,CA,PacificPrevailing
-06109,Tuolumne,CA,PacificPrevailing
-06111,Ventura,CA,PacificPrevailing
-06113,Yolo,CA,PacificPrevailing
-06115,Yuba,CA,PacificPrevailing
-08001,Adams,CO,MountainPrevailing
-08003,Alamosa,CO,MountainPrevailing
-08005,Arapahoe,CO,MountainPrevailing
-08007,Archuleta,CO,MountainPrevailing
-08009,Baca,CO,MountainPrevailing
-08011,Bent,CO,MountainPrevailing
-08013,Boulder,CO,MountainPrevailing
-08014,Broomfield,CO,MountainPrevailing
-08015,Chaffee,CO,MountainPrevailing
-08017,Cheyenne,CO,MountainPrevailing
-08019,Clear Creek,CO,MountainPrevailing
-08021,Conejos,CO,MountainPrevailing
-08023,Costilla,CO,MountainPrevailing
-08025,Crowley,CO,MountainPrevailing
-08027,Custer,CO,MountainPrevailing
-08029,Delta,CO,MountainPrevailing
-08031,Denver,CO,MountainPrevailing
-08033,Dolores,CO,MountainPrevailing
-08035,Douglas,CO,MountainPrevailing
-08037,Eagle,CO,MountainPrevailing
-08039,Elbert,CO,MountainPrevailing
-08041,El Paso,CO,MountainPrevailing
-08043,Fremont,CO,MountainPrevailing
-08045,Garfield,CO,MountainPrevailing
-08047,Gilpin,CO,MountainPrevailing
-08049,Grand,CO,MountainPrevailing
-08051,Gunnison,CO,MountainPrevailing
-08053,Hinsdale,CO,MountainPrevailing
-08055,Huerfano,CO,MountainPrevailing
-08057,Jackson,CO,MountainPrevailing
-08059,Jefferson,CO,MountainPrevailing
-08061,Kiowa,CO,MountainPrevailing
-08063,Kit Carson,CO,MountainPrevailing
-08065,Lake,CO,MountainPrevailing
-08067,La Plata,CO,MountainPrevailing
-08069,Larimer,CO,MountainPrevailing
-08071,Las Animas,CO,MountainPrevailing
-08073,Lincoln,CO,MountainPrevailing
-08075,Logan,CO,MountainPrevailing
-08077,Mesa,CO,MountainPrevailing
-08079,Mineral,CO,MountainPrevailing
-08081,Moffat,CO,MountainPrevailing
-08083,Montezuma,CO,MountainPrevailing
-08085,Montrose,CO,MountainPrevailing
-08087,Morgan,CO,MountainPrevailing
-08089,Otero,CO,MountainPrevailing
-08091,Ouray,CO,MountainPrevailing
-08093,Park,CO,MountainPrevailing
-08095,Phillips,CO,MountainPrevailing
-08097,Pitkin,CO,MountainPrevailing
-08099,Prowers,CO,MountainPrevailing
-08101,Pueblo,CO,MountainPrevailing
-08103,Rio Blanco,CO,MountainPrevailing
-08105,Rio Grande,CO,MountainPrevailing
-08107,Routt,CO,MountainPrevailing
-08109,Saguache,CO,MountainPrevailing
-08111,San Juan,CO,MountainPrevailing
-08113,San Miguel,CO,MountainPrevailing
-08115,Sedgwick,CO,MountainPrevailing
-08117,Summit,CO,MountainPrevailing
-08119,Teller,CO,MountainPrevailing
-08121,Washington,CO,MountainPrevailing
-08123,Weld,CO,MountainPrevailing
-08125,Yuma,CO,MountainPrevailing
-09001,Fairfield,CT,EasternPrevailing
-09003,Hartford,CT,EasternPrevailing
-09005,Litchfield,CT,EasternPrevailing
-09007,Middlesex,CT,EasternPrevailing
-09009,New Haven,CT,EasternPrevailing
-09011,New London,CT,EasternPrevailing
-09013,Tolland,CT,EasternPrevailing
-09015,Windham,CT,EasternPrevailing
+1001,Autauga,AL,CentralPrevailing
+1003,Baldwin,AL,CentralPrevailing
+1005,Barbour,AL,CentralPrevailing
+1007,Bibb,AL,CentralPrevailing
+1009,Blount,AL,CentralPrevailing
+1011,Bullock,AL,CentralPrevailing
+1013,Butler,AL,CentralPrevailing
+1015,Calhoun,AL,CentralPrevailing
+1017,Chambers,AL,CentralPrevailing
+1019,Cherokee,AL,CentralPrevailing
+1021,Chilton,AL,CentralPrevailing
+1023,Choctaw,AL,CentralPrevailing
+1025,Clarke,AL,CentralPrevailing
+1027,Clay,AL,CentralPrevailing
+1029,Cleburne,AL,CentralPrevailing
+1031,Coffee,AL,CentralPrevailing
+1033,Colbert,AL,CentralPrevailing
+1035,Conecuh,AL,CentralPrevailing
+1037,Coosa,AL,CentralPrevailing
+1039,Covington,AL,CentralPrevailing
+1041,Crenshaw,AL,CentralPrevailing
+1043,Cullman,AL,CentralPrevailing
+1045,Dale,AL,CentralPrevailing
+1047,Dallas,AL,CentralPrevailing
+1049,DeKalb,AL,CentralPrevailing
+1051,Elmore,AL,CentralPrevailing
+1053,Escambia,AL,CentralPrevailing
+1055,Etowah,AL,CentralPrevailing
+1057,Fayette,AL,CentralPrevailing
+1059,Franklin,AL,CentralPrevailing
+1061,Geneva,AL,CentralPrevailing
+1063,Greene,AL,CentralPrevailing
+1065,Hale,AL,CentralPrevailing
+1067,Henry,AL,CentralPrevailing
+1069,Houston,AL,CentralPrevailing
+1071,Jackson,AL,CentralPrevailing
+1073,Jefferson,AL,CentralPrevailing
+1075,Lamar,AL,CentralPrevailing
+1077,Lauderdale,AL,CentralPrevailing
+1079,Lawrence,AL,CentralPrevailing
+1081,Lee,AL,CentralPrevailing
+1083,Limestone,AL,CentralPrevailing
+1085,Lowndes,AL,CentralPrevailing
+1087,Macon,AL,CentralPrevailing
+1089,Madison,AL,CentralPrevailing
+1091,Marengo,AL,CentralPrevailing
+1093,Marion,AL,CentralPrevailing
+1095,Marshall,AL,CentralPrevailing
+1097,Mobile,AL,CentralPrevailing
+1099,Monroe,AL,CentralPrevailing
+1101,Montgomery,AL,CentralPrevailing
+1103,Morgan,AL,CentralPrevailing
+1105,Perry,AL,CentralPrevailing
+1107,Pickens,AL,CentralPrevailing
+1109,Pike,AL,CentralPrevailing
+1111,Randolph,AL,CentralPrevailing
+1113,Russell,AL,CentralPrevailing
+1115,St. Clair,AL,CentralPrevailing
+1117,Shelby,AL,CentralPrevailing
+1119,Sumter,AL,CentralPrevailing
+1121,Talladega,AL,CentralPrevailing
+1123,Tallapoosa,AL,CentralPrevailing
+1125,Tuscaloosa,AL,CentralPrevailing
+1127,Walker,AL,CentralPrevailing
+1129,Washington,AL,CentralPrevailing
+1131,Wilcox,AL,CentralPrevailing
+1133,Winston,AL,CentralPrevailing
+4001,Apache,AZ,MountainStandard
+4003,Cochise,AZ,MountainStandard
+4005,Coconino,AZ,MountainStandard
+4007,Gila,AZ,MountainStandard
+4009,Graham,AZ,MountainStandard
+4011,Greenlee,AZ,MountainStandard
+4012,La Paz,AZ,MountainStandard
+4013,Maricopa,AZ,MountainStandard
+4015,Mohave,AZ,MountainStandard
+4017,Navajo,AZ,MountainPrevailing
+4019,Pima,AZ,MountainStandard
+4021,Pinal,AZ,MountainStandard
+4023,Santa Cruz,AZ,MountainStandard
+4025,Yavapai,AZ,MountainStandard
+4027,Yuma,AZ,MountainStandard
+5001,Arkansas,AR,CentralPrevailing
+5003,Ashley,AR,CentralPrevailing
+5005,Baxter,AR,CentralPrevailing
+5007,Benton,AR,CentralPrevailing
+5009,Boone,AR,CentralPrevailing
+5011,Bradley,AR,CentralPrevailing
+5013,Calhoun,AR,CentralPrevailing
+5015,Carroll,AR,CentralPrevailing
+5017,Chicot,AR,CentralPrevailing
+5019,Clark,AR,CentralPrevailing
+5021,Clay,AR,CentralPrevailing
+5023,Cleburne,AR,CentralPrevailing
+5025,Cleveland,AR,CentralPrevailing
+5027,Columbia,AR,CentralPrevailing
+5029,Conway,AR,CentralPrevailing
+5031,Craighead,AR,CentralPrevailing
+5033,Crawford,AR,CentralPrevailing
+5035,Crittenden,AR,CentralPrevailing
+5037,Cross,AR,CentralPrevailing
+5039,Dallas,AR,CentralPrevailing
+5041,Desha,AR,CentralPrevailing
+5043,Drew,AR,CentralPrevailing
+5045,Faulkner,AR,CentralPrevailing
+5047,Franklin,AR,CentralPrevailing
+5049,Fulton,AR,CentralPrevailing
+5051,Garland,AR,CentralPrevailing
+5053,Grant,AR,CentralPrevailing
+5055,Greene,AR,CentralPrevailing
+5057,Hempstead,AR,CentralPrevailing
+5059,Hot Spring,AR,CentralPrevailing
+5061,Howard,AR,CentralPrevailing
+5063,Independence,AR,CentralPrevailing
+5065,Izard,AR,CentralPrevailing
+5067,Jackson,AR,CentralPrevailing
+5069,Jefferson,AR,CentralPrevailing
+5071,Johnson,AR,CentralPrevailing
+5073,Lafayette,AR,CentralPrevailing
+5075,Lawrence,AR,CentralPrevailing
+5077,Lee,AR,CentralPrevailing
+5079,Lincoln,AR,CentralPrevailing
+5081,Little River,AR,CentralPrevailing
+5083,Logan,AR,CentralPrevailing
+5085,Lonoke,AR,CentralPrevailing
+5087,Madison,AR,CentralPrevailing
+5089,Marion,AR,CentralPrevailing
+5091,Miller,AR,CentralPrevailing
+5093,Mississippi,AR,CentralPrevailing
+5095,Monroe,AR,CentralPrevailing
+5097,Montgomery,AR,CentralPrevailing
+5099,Nevada,AR,CentralPrevailing
+5101,Newton,AR,CentralPrevailing
+5103,Ouachita,AR,CentralPrevailing
+5105,Perry,AR,CentralPrevailing
+5107,Phillips,AR,CentralPrevailing
+5109,Pike,AR,CentralPrevailing
+5111,Poinsett,AR,CentralPrevailing
+5113,Polk,AR,CentralPrevailing
+5115,Pope,AR,CentralPrevailing
+5117,Prairie,AR,CentralPrevailing
+5119,Pulaski,AR,CentralPrevailing
+5121,Randolph,AR,CentralPrevailing
+5123,St. Francis,AR,CentralPrevailing
+5125,Saline,AR,CentralPrevailing
+5127,Scott,AR,CentralPrevailing
+5129,Searcy,AR,CentralPrevailing
+5131,Sebastian,AR,CentralPrevailing
+5133,Sevier,AR,CentralPrevailing
+5135,Sharp,AR,CentralPrevailing
+5137,Stone,AR,CentralPrevailing
+5139,Union,AR,CentralPrevailing
+5141,Van Buren,AR,CentralPrevailing
+5143,Washington,AR,CentralPrevailing
+5145,White,AR,CentralPrevailing
+5147,Woodruff,AR,CentralPrevailing
+5149,Yell,AR,CentralPrevailing
+6001,Alameda,CA,PacificPrevailing
+6003,Alpine,CA,PacificPrevailing
+6005,Amador,CA,PacificPrevailing
+6007,Butte,CA,PacificPrevailing
+6009,Calaveras,CA,PacificPrevailing
+6011,Colusa,CA,PacificPrevailing
+6013,Contra Costa,CA,PacificPrevailing
+6015,Del Norte,CA,PacificPrevailing
+6017,El Dorado,CA,PacificPrevailing
+6019,Fresno,CA,PacificPrevailing
+6021,Glenn,CA,PacificPrevailing
+6023,Humboldt,CA,PacificPrevailing
+6025,Imperial,CA,PacificPrevailing
+6027,Inyo,CA,PacificPrevailing
+6029,Kern,CA,PacificPrevailing
+6031,Kings,CA,PacificPrevailing
+6033,Lake,CA,PacificPrevailing
+6035,Lassen,CA,PacificPrevailing
+6037,Los Angeles,CA,PacificPrevailing
+6039,Madera,CA,PacificPrevailing
+6041,Marin,CA,PacificPrevailing
+6043,Mariposa,CA,PacificPrevailing
+6045,Mendocino,CA,PacificPrevailing
+6047,Merced,CA,PacificPrevailing
+6049,Modoc,CA,PacificPrevailing
+6051,Mono,CA,PacificPrevailing
+6053,Monterey,CA,PacificPrevailing
+6055,Napa,CA,PacificPrevailing
+6057,Nevada,CA,PacificPrevailing
+6059,Orange,CA,PacificPrevailing
+6061,Placer,CA,PacificPrevailing
+6063,Plumas,CA,PacificPrevailing
+6065,Riverside,CA,PacificPrevailing
+6067,Sacramento,CA,PacificPrevailing
+6069,San Benito,CA,PacificPrevailing
+6071,San Bernardino,CA,PacificPrevailing
+6073,San Diego,CA,PacificPrevailing
+6075,San Francisco,CA,PacificPrevailing
+6077,San Joaquin,CA,PacificPrevailing
+6079,San Luis Obispo,CA,PacificPrevailing
+6081,San Mateo,CA,PacificPrevailing
+6083,Santa Barbara,CA,PacificPrevailing
+6085,Santa Clara,CA,PacificPrevailing
+6087,Santa Cruz,CA,PacificPrevailing
+6089,Shasta,CA,PacificPrevailing
+6091,Sierra,CA,PacificPrevailing
+6093,Siskiyou,CA,PacificPrevailing
+6095,Solano,CA,PacificPrevailing
+6097,Sonoma,CA,PacificPrevailing
+6099,Stanislaus,CA,PacificPrevailing
+6101,Sutter,CA,PacificPrevailing
+6103,Tehama,CA,PacificPrevailing
+6105,Trinity,CA,PacificPrevailing
+6107,Tulare,CA,PacificPrevailing
+6109,Tuolumne,CA,PacificPrevailing
+6111,Ventura,CA,PacificPrevailing
+6113,Yolo,CA,PacificPrevailing
+6115,Yuba,CA,PacificPrevailing
+8001,Adams,CO,MountainPrevailing
+8003,Alamosa,CO,MountainPrevailing
+8005,Arapahoe,CO,MountainPrevailing
+8007,Archuleta,CO,MountainPrevailing
+8009,Baca,CO,MountainPrevailing
+8011,Bent,CO,MountainPrevailing
+8013,Boulder,CO,MountainPrevailing
+8014,Broomfield,CO,MountainPrevailing
+8015,Chaffee,CO,MountainPrevailing
+8017,Cheyenne,CO,MountainPrevailing
+8019,Clear Creek,CO,MountainPrevailing
+8021,Conejos,CO,MountainPrevailing
+8023,Costilla,CO,MountainPrevailing
+8025,Crowley,CO,MountainPrevailing
+8027,Custer,CO,MountainPrevailing
+8029,Delta,CO,MountainPrevailing
+8031,Denver,CO,MountainPrevailing
+8033,Dolores,CO,MountainPrevailing
+8035,Douglas,CO,MountainPrevailing
+8037,Eagle,CO,MountainPrevailing
+8039,Elbert,CO,MountainPrevailing
+8041,El Paso,CO,MountainPrevailing
+8043,Fremont,CO,MountainPrevailing
+8045,Garfield,CO,MountainPrevailing
+8047,Gilpin,CO,MountainPrevailing
+8049,Grand,CO,MountainPrevailing
+8051,Gunnison,CO,MountainPrevailing
+8053,Hinsdale,CO,MountainPrevailing
+8055,Huerfano,CO,MountainPrevailing
+8057,Jackson,CO,MountainPrevailing
+8059,Jefferson,CO,MountainPrevailing
+8061,Kiowa,CO,MountainPrevailing
+8063,Kit Carson,CO,MountainPrevailing
+8065,Lake,CO,MountainPrevailing
+8067,La Plata,CO,MountainPrevailing
+8069,Larimer,CO,MountainPrevailing
+8071,Las Animas,CO,MountainPrevailing
+8073,Lincoln,CO,MountainPrevailing
+8075,Logan,CO,MountainPrevailing
+8077,Mesa,CO,MountainPrevailing
+8079,Mineral,CO,MountainPrevailing
+8081,Moffat,CO,MountainPrevailing
+8083,Montezuma,CO,MountainPrevailing
+8085,Montrose,CO,MountainPrevailing
+8087,Morgan,CO,MountainPrevailing
+8089,Otero,CO,MountainPrevailing
+8091,Ouray,CO,MountainPrevailing
+8093,Park,CO,MountainPrevailing
+8095,Phillips,CO,MountainPrevailing
+8097,Pitkin,CO,MountainPrevailing
+8099,Prowers,CO,MountainPrevailing
+8101,Pueblo,CO,MountainPrevailing
+8103,Rio Blanco,CO,MountainPrevailing
+8105,Rio Grande,CO,MountainPrevailing
+8107,Routt,CO,MountainPrevailing
+8109,Saguache,CO,MountainPrevailing
+8111,San Juan,CO,MountainPrevailing
+8113,San Miguel,CO,MountainPrevailing
+8115,Sedgwick,CO,MountainPrevailing
+8117,Summit,CO,MountainPrevailing
+8119,Teller,CO,MountainPrevailing
+8121,Washington,CO,MountainPrevailing
+8123,Weld,CO,MountainPrevailing
+8125,Yuma,CO,MountainPrevailing
+9001,Fairfield,CT,EasternPrevailing
+9003,Hartford,CT,EasternPrevailing
+9005,Litchfield,CT,EasternPrevailing
+9007,Middlesex,CT,EasternPrevailing
+9009,New Haven,CT,EasternPrevailing
+9011,New London,CT,EasternPrevailing
+9013,Tolland,CT,EasternPrevailing
+9015,Windham,CT,EasternPrevailing
 10001,Kent,DE,EasternPrevailing
 10003,New Castle,DE,EasternPrevailing
 10005,Sussex,DE,EasternPrevailing
@@ -1767,7 +1767,7 @@ id,name,state,time_zone
 35007,Colfax,NM,MountainPrevailing
 35009,Curry,NM,MountainPrevailing
 35011,De Baca,NM,MountainPrevailing
-35013,Do?a Ana,NM,MountainPrevailing
+35013,Dona Ana,NM,MountainPrevailing
 35015,Eddy,NM,MountainPrevailing
 35017,Grant,NM,MountainPrevailing
 35019,Guadalupe,NM,MountainPrevailing

--- a/dsgrid_project/scripts/make_county_tz_map_from_resstock_options_lookup.py
+++ b/dsgrid_project/scripts/make_county_tz_map_from_resstock_options_lookup.py
@@ -1,0 +1,180 @@
+"""Make time zone mapping for county.csv using resstock's options_lookup
+created on 06/19/2024
+
+County files used:
+- dsgrid-project-StandardScenarios/dsgrid_project/dimensions/counties.csv
+- dsgrid-project-StandardScenarios/tempo_project/dimensions/counties.csv
+- dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/resstock/dimensions/conus_2022-resstock_geography_county_fips.csv
+- dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/comstock/dimensions/conus_2022-comstock_geography_county_fips.csv
+- dsgrid-project-DECARB/project/dimensions/counties.csv
+"""
+
+import pandas as pd
+from pathlib import Path
+import argparse
+
+
+def main(county_file: str, lookup_file: str, pre2015_counties=False):
+    # Process lookup file
+    lookup_file = Path(lookup_file)
+    assert (
+        lookup_file.name == "options_lookup.tsv"
+    ), "lookup_file needs to have name: 'options_lookup.tsv'"
+    lkup = pd.read_csv(lookup_file, sep="\t")
+    lkup = (
+        lkup.loc[lkup["Parameter Name"] == "County"]
+        .dropna(how="all", axis=1)
+        .reset_index(drop=True)
+    )
+    lkup = lkup[["Option Name", "Unnamed: 6"]]
+    lkup["Option Name"] = (
+        lkup["Option Name"]
+        .str.lower()
+        .str.removesuffix("county")
+        .str.strip()
+        .str.removesuffix("city and borough")
+        .str.strip()
+        .str.removesuffix("city")
+        .str.strip()
+        .str.removesuffix("parish")
+        .str.strip()
+        .str.removesuffix("borough")
+        .str.strip()
+        .str.removesuffix("census area")
+        .str.strip()
+        .str.removesuffix("municipality")
+        .str.strip()
+        .str.replace("'", "")
+        .str.replace(".", "")
+    )
+    lkup["time_zone"] = (
+        lkup["Unnamed: 6"]
+        .str.removeprefix("site_time_zone_utc_offset=")
+        .map(
+            {
+                "-5": "EasternPrevailing",
+                "-6": "CentralPrevailing",
+                "-7": "MountainPrevailing",
+                "-8": "PacificPrevailing",
+                "-9": "AlaskaPrevailing",
+                "-10": "HawaiiAleutianStandard",
+            }
+        )
+    )
+
+    # Add AZ exceptions
+    cond = lkup["Option Name"].str.contains("az,")
+    cond2 = cond & (~lkup["Option Name"].str.contains("navajo"))
+    lkup.loc[cond2, "time_zone"] = "USArizona"
+    print("Adjusted time zones for AZ in lookup:")
+    print(lkup.loc[cond])
+
+    # Check map for duplicated rows (Option Name formatting can cause duplicates)
+    dup_by_name = lkup.loc[
+        lkup["Option Name"].isin(
+            lkup.loc[lkup["Option Name"].duplicated(), "Option Name"]
+        )
+    ]
+    dup_by_row = lkup.loc[
+        lkup["Option Name"].isin(lkup.loc[lkup.duplicated(), "Option Name"])
+    ]
+    assert (
+        len(dup_by_name.compare(dup_by_row)) == 0
+    ), "Duplicated Option Name found that do not share the same time zone, cannot drop rows."
+    lkup = lkup.drop_duplicates()
+
+    # Map to county file
+    county_file = Path(county_file)
+    df = pd.read_csv(county_file)
+    n_df = len(df)
+
+    has_old_time_zone = False
+    if "time_zone" in df.columns:
+        df = df.rename(columns={"time_zone": "old_time_zone"})
+        has_old_time_zone = True
+    df["map_key"] = (
+        (df["state"] + ", " + df["name"])
+        .str.lower()
+        .str.removesuffix("county")
+        .str.strip()
+        .str.removesuffix("city and borough")
+        .str.strip()
+        .str.removesuffix("city")
+        .str.strip()
+        .str.removesuffix("parish")
+        .str.strip()
+        .str.removesuffix("borough")
+        .str.strip()
+        .str.removesuffix("census area")
+        .str.strip()
+        .str.removesuffix("municipality")
+        .str.strip()
+        .str.replace("'", "")
+        .str.replace(".", "")
+    )
+
+    ## Fix discrepancies and old county names
+    county_map = {
+        "la, lasalle": "la, la salle",
+        "ak, wade hampton": "ak, kusilvak",
+        "sd, shannon": "sd, oglala lakota",
+    }
+    for key, val in county_map.items():
+        cond = df["map_key"] == key
+        if len(df.loc[cond]) == 1:
+            df.loc[cond, "map_key"] = val
+
+    df = df.join(lkup.set_index("Option Name")["time_zone"], on="map_key", how="left")
+
+    # Check mapping
+    not_mapped = df.loc[df["time_zone"].isna()]
+    # assert len(not_mapped) == 0, f"counties not mapped:\n{not_mapped}"
+    avail_mapping = lkup.loc[~lkup["Option Name"].isin(df["map_key"])]
+    if len(not_mapped) > 0:
+        print(f"Counties not mapped:\n{not_mapped}")
+        print(f"Available mapping:\n{avail_mapping}")
+        breakpoint()
+    if len(avail_mapping) > 0:
+        print("\nWarning: the following counties from options_lookup are unmapped:")
+        print(avail_mapping)
+
+    # Check old and new time_zone
+    if has_old_time_zone:
+        cond = df["time_zone"] != df["old_time_zone"]
+        cols = [x for x in df.columns if x != "map_key"]
+        print("\nDifference between old and new time_zone:")
+        print(df.loc[cond, cols])
+
+    # Clean up and save
+    if df["id"].dtype == float or df["id"].dtype == int:
+        df["id"] = df["id"].astype(int).astype(str).str.zfill(5)
+    df = df.drop(columns=["old_time_zone", "map_key"])
+    # assert len(df) == n_df, "county df does not have the same number of rows as before."
+    if len(df) != n_df:
+        print("county df does not have the same number of rows as before.")
+        breakpoint()
+
+    df.to_csv(county_file, index=False)
+    print(f"\nUpdated time_zone column in county file: {county_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "county_file",
+        action="store",
+        default=None,
+        nargs="?",
+        help="Path to dsgrid geography record: county.csv",
+    )
+    parser.add_argument(
+        "lookup_file",
+        action="store",
+        default=None,
+        nargs="?",
+        help="Path to ResStock options_lookup tsv file. i.e., "
+        "https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv",
+    )
+
+    args = parser.parse_args()
+    main(args.county_file, args.lookup_file)

--- a/dsgrid_project/scripts/make_county_tz_map_from_resstock_options_lookup.py
+++ b/dsgrid_project/scripts/make_county_tz_map_from_resstock_options_lookup.py
@@ -128,15 +128,11 @@ def main(county_file: str, lookup_file: str, pre2015_counties=False):
 
     # Check mapping
     not_mapped = df.loc[df["time_zone"].isna()]
-    # assert len(not_mapped) == 0, f"counties not mapped:\n{not_mapped}"
     avail_mapping = lkup.loc[~lkup["Option Name"].isin(df["map_key"])]
-    if len(not_mapped) > 0:
-        print(f"Counties not mapped:\n{not_mapped}")
-        print(f"Available mapping:\n{avail_mapping}")
-        breakpoint()
     if len(avail_mapping) > 0:
         print("\nWarning: the following counties from options_lookup are unmapped:")
         print(avail_mapping)
+    assert len(not_mapped) == 0, f"counties not mapped:\n{not_mapped}"
 
     # Check old and new time_zone
     if has_old_time_zone:
@@ -149,10 +145,7 @@ def main(county_file: str, lookup_file: str, pre2015_counties=False):
     if df["id"].dtype == float or df["id"].dtype == int:
         df["id"] = df["id"].astype(int).astype(str).str.zfill(5)
     df = df.drop(columns=["old_time_zone", "map_key"])
-    # assert len(df) == n_df, "county df does not have the same number of rows as before."
-    if len(df) != n_df:
-        print("county df does not have the same number of rows as before.")
-        breakpoint()
+    assert len(df) == n_df, "county df does not have the same number of rows as before."
 
     df.to_csv(county_file, index=False)
     print(f"\nUpdated time_zone column in county file: {county_file}")

--- a/tempo_project/dimensions/counties.csv
+++ b/tempo_project/dimensions/counties.csv
@@ -1,291 +1,291 @@
 id,name,state,time_zone
-1001,Autauga,AL,CentralPrevailing
-1003,Baldwin,AL,CentralPrevailing
-1005,Barbour,AL,CentralPrevailing
-1007,Bibb,AL,CentralPrevailing
-1009,Blount,AL,CentralPrevailing
-1011,Bullock,AL,CentralPrevailing
-1013,Butler,AL,CentralPrevailing
-1015,Calhoun,AL,CentralPrevailing
-1017,Chambers,AL,CentralPrevailing
-1019,Cherokee,AL,CentralPrevailing
-1021,Chilton,AL,CentralPrevailing
-1023,Choctaw,AL,CentralPrevailing
-1025,Clarke,AL,CentralPrevailing
-1027,Clay,AL,CentralPrevailing
-1029,Cleburne,AL,CentralPrevailing
-1031,Coffee,AL,CentralPrevailing
-1033,Colbert,AL,CentralPrevailing
-1035,Conecuh,AL,CentralPrevailing
-1037,Coosa,AL,CentralPrevailing
-1039,Covington,AL,CentralPrevailing
-1041,Crenshaw,AL,CentralPrevailing
-1043,Cullman,AL,CentralPrevailing
-1045,Dale,AL,CentralPrevailing
-1047,Dallas,AL,CentralPrevailing
-1049,DeKalb,AL,CentralPrevailing
-1051,Elmore,AL,CentralPrevailing
-1053,Escambia,AL,CentralPrevailing
-1055,Etowah,AL,CentralPrevailing
-1057,Fayette,AL,CentralPrevailing
-1059,Franklin,AL,CentralPrevailing
-1061,Geneva,AL,CentralPrevailing
-1063,Greene,AL,CentralPrevailing
-1065,Hale,AL,CentralPrevailing
-1067,Henry,AL,CentralPrevailing
-1069,Houston,AL,CentralPrevailing
-1071,Jackson,AL,CentralPrevailing
-1073,Jefferson,AL,CentralPrevailing
-1075,Lamar,AL,CentralPrevailing
-1077,Lauderdale,AL,CentralPrevailing
-1079,Lawrence,AL,CentralPrevailing
-1081,Lee,AL,CentralPrevailing
-1083,Limestone,AL,CentralPrevailing
-1085,Lowndes,AL,CentralPrevailing
-1087,Macon,AL,CentralPrevailing
-1089,Madison,AL,CentralPrevailing
-1091,Marengo,AL,CentralPrevailing
-1093,Marion,AL,CentralPrevailing
-1095,Marshall,AL,CentralPrevailing
-1097,Mobile,AL,CentralPrevailing
-1099,Monroe,AL,CentralPrevailing
-1101,Montgomery,AL,CentralPrevailing
-1103,Morgan,AL,CentralPrevailing
-1105,Perry,AL,CentralPrevailing
-1107,Pickens,AL,CentralPrevailing
-1109,Pike,AL,CentralPrevailing
-1111,Randolph,AL,CentralPrevailing
-1113,Russell,AL,CentralPrevailing
-1115,St. Clair,AL,CentralPrevailing
-1117,Shelby,AL,CentralPrevailing
-1119,Sumter,AL,CentralPrevailing
-1121,Talladega,AL,CentralPrevailing
-1123,Tallapoosa,AL,CentralPrevailing
-1125,Tuscaloosa,AL,CentralPrevailing
-1127,Walker,AL,CentralPrevailing
-1129,Washington,AL,CentralPrevailing
-1131,Wilcox,AL,CentralPrevailing
-1133,Winston,AL,CentralPrevailing
-4001,Apache,AZ,MountainStandard
-4003,Cochise,AZ,MountainStandard
-4005,Coconino,AZ,MountainStandard
-4007,Gila,AZ,MountainStandard
-4009,Graham,AZ,MountainStandard
-4011,Greenlee,AZ,MountainStandard
-4012,La Paz,AZ,MountainStandard
-4013,Maricopa,AZ,MountainStandard
-4015,Mohave,AZ,MountainStandard
-4017,Navajo,AZ,MountainPrevailing
-4019,Pima,AZ,MountainStandard
-4021,Pinal,AZ,MountainStandard
-4023,Santa Cruz,AZ,MountainStandard
-4025,Yavapai,AZ,MountainStandard
-4027,Yuma,AZ,MountainStandard
-5001,Arkansas,AR,CentralPrevailing
-5003,Ashley,AR,CentralPrevailing
-5005,Baxter,AR,CentralPrevailing
-5007,Benton,AR,CentralPrevailing
-5009,Boone,AR,CentralPrevailing
-5011,Bradley,AR,CentralPrevailing
-5013,Calhoun,AR,CentralPrevailing
-5015,Carroll,AR,CentralPrevailing
-5017,Chicot,AR,CentralPrevailing
-5019,Clark,AR,CentralPrevailing
-5021,Clay,AR,CentralPrevailing
-5023,Cleburne,AR,CentralPrevailing
-5025,Cleveland,AR,CentralPrevailing
-5027,Columbia,AR,CentralPrevailing
-5029,Conway,AR,CentralPrevailing
-5031,Craighead,AR,CentralPrevailing
-5033,Crawford,AR,CentralPrevailing
-5035,Crittenden,AR,CentralPrevailing
-5037,Cross,AR,CentralPrevailing
-5039,Dallas,AR,CentralPrevailing
-5041,Desha,AR,CentralPrevailing
-5043,Drew,AR,CentralPrevailing
-5045,Faulkner,AR,CentralPrevailing
-5047,Franklin,AR,CentralPrevailing
-5049,Fulton,AR,CentralPrevailing
-5051,Garland,AR,CentralPrevailing
-5053,Grant,AR,CentralPrevailing
-5055,Greene,AR,CentralPrevailing
-5057,Hempstead,AR,CentralPrevailing
-5059,Hot Spring,AR,CentralPrevailing
-5061,Howard,AR,CentralPrevailing
-5063,Independence,AR,CentralPrevailing
-5065,Izard,AR,CentralPrevailing
-5067,Jackson,AR,CentralPrevailing
-5069,Jefferson,AR,CentralPrevailing
-5071,Johnson,AR,CentralPrevailing
-5073,Lafayette,AR,CentralPrevailing
-5075,Lawrence,AR,CentralPrevailing
-5077,Lee,AR,CentralPrevailing
-5079,Lincoln,AR,CentralPrevailing
-5081,Little River,AR,CentralPrevailing
-5083,Logan,AR,CentralPrevailing
-5085,Lonoke,AR,CentralPrevailing
-5087,Madison,AR,CentralPrevailing
-5089,Marion,AR,CentralPrevailing
-5091,Miller,AR,CentralPrevailing
-5093,Mississippi,AR,CentralPrevailing
-5095,Monroe,AR,CentralPrevailing
-5097,Montgomery,AR,CentralPrevailing
-5099,Nevada,AR,CentralPrevailing
-5101,Newton,AR,CentralPrevailing
-5103,Ouachita,AR,CentralPrevailing
-5105,Perry,AR,CentralPrevailing
-5107,Phillips,AR,CentralPrevailing
-5109,Pike,AR,CentralPrevailing
-5111,Poinsett,AR,CentralPrevailing
-5113,Polk,AR,CentralPrevailing
-5115,Pope,AR,CentralPrevailing
-5117,Prairie,AR,CentralPrevailing
-5119,Pulaski,AR,CentralPrevailing
-5121,Randolph,AR,CentralPrevailing
-5123,St. Francis,AR,CentralPrevailing
-5125,Saline,AR,CentralPrevailing
-5127,Scott,AR,CentralPrevailing
-5129,Searcy,AR,CentralPrevailing
-5131,Sebastian,AR,CentralPrevailing
-5133,Sevier,AR,CentralPrevailing
-5135,Sharp,AR,CentralPrevailing
-5137,Stone,AR,CentralPrevailing
-5139,Union,AR,CentralPrevailing
-5141,Van Buren,AR,CentralPrevailing
-5143,Washington,AR,CentralPrevailing
-5145,White,AR,CentralPrevailing
-5147,Woodruff,AR,CentralPrevailing
-5149,Yell,AR,CentralPrevailing
-6001,Alameda,CA,PacificPrevailing
-6003,Alpine,CA,PacificPrevailing
-6005,Amador,CA,PacificPrevailing
-6007,Butte,CA,PacificPrevailing
-6009,Calaveras,CA,PacificPrevailing
-6011,Colusa,CA,PacificPrevailing
-6013,Contra Costa,CA,PacificPrevailing
-6015,Del Norte,CA,PacificPrevailing
-6017,El Dorado,CA,PacificPrevailing
-6019,Fresno,CA,PacificPrevailing
-6021,Glenn,CA,PacificPrevailing
-6023,Humboldt,CA,PacificPrevailing
-6025,Imperial,CA,PacificPrevailing
-6027,Inyo,CA,PacificPrevailing
-6029,Kern,CA,PacificPrevailing
-6031,Kings,CA,PacificPrevailing
-6033,Lake,CA,PacificPrevailing
-6035,Lassen,CA,PacificPrevailing
-6037,Los Angeles,CA,PacificPrevailing
-6039,Madera,CA,PacificPrevailing
-6041,Marin,CA,PacificPrevailing
-6043,Mariposa,CA,PacificPrevailing
-6045,Mendocino,CA,PacificPrevailing
-6047,Merced,CA,PacificPrevailing
-6049,Modoc,CA,PacificPrevailing
-6051,Mono,CA,PacificPrevailing
-6053,Monterey,CA,PacificPrevailing
-6055,Napa,CA,PacificPrevailing
-6057,Nevada,CA,PacificPrevailing
-6059,Orange,CA,PacificPrevailing
-6061,Placer,CA,PacificPrevailing
-6063,Plumas,CA,PacificPrevailing
-6065,Riverside,CA,PacificPrevailing
-6067,Sacramento,CA,PacificPrevailing
-6069,San Benito,CA,PacificPrevailing
-6071,San Bernardino,CA,PacificPrevailing
-6073,San Diego,CA,PacificPrevailing
-6075,San Francisco,CA,PacificPrevailing
-6077,San Joaquin,CA,PacificPrevailing
-6079,San Luis Obispo,CA,PacificPrevailing
-6081,San Mateo,CA,PacificPrevailing
-6083,Santa Barbara,CA,PacificPrevailing
-6085,Santa Clara,CA,PacificPrevailing
-6087,Santa Cruz,CA,PacificPrevailing
-6089,Shasta,CA,PacificPrevailing
-6091,Sierra,CA,PacificPrevailing
-6093,Siskiyou,CA,PacificPrevailing
-6095,Solano,CA,PacificPrevailing
-6097,Sonoma,CA,PacificPrevailing
-6099,Stanislaus,CA,PacificPrevailing
-6101,Sutter,CA,PacificPrevailing
-6103,Tehama,CA,PacificPrevailing
-6105,Trinity,CA,PacificPrevailing
-6107,Tulare,CA,PacificPrevailing
-6109,Tuolumne,CA,PacificPrevailing
-6111,Ventura,CA,PacificPrevailing
-6113,Yolo,CA,PacificPrevailing
-6115,Yuba,CA,PacificPrevailing
-8001,Adams,CO,MountainPrevailing
-8003,Alamosa,CO,MountainPrevailing
-8005,Arapahoe,CO,MountainPrevailing
-8007,Archuleta,CO,MountainPrevailing
-8009,Baca,CO,MountainPrevailing
-8011,Bent,CO,MountainPrevailing
-8013,Boulder,CO,MountainPrevailing
-8014,Broomfield,CO,MountainPrevailing
-8015,Chaffee,CO,MountainPrevailing
-8017,Cheyenne,CO,MountainPrevailing
-8019,Clear Creek,CO,MountainPrevailing
-8021,Conejos,CO,MountainPrevailing
-8023,Costilla,CO,MountainPrevailing
-8025,Crowley,CO,MountainPrevailing
-8027,Custer,CO,MountainPrevailing
-8029,Delta,CO,MountainPrevailing
-8031,Denver,CO,MountainPrevailing
-8033,Dolores,CO,MountainPrevailing
-8035,Douglas,CO,MountainPrevailing
-8037,Eagle,CO,MountainPrevailing
-8039,Elbert,CO,MountainPrevailing
-8041,El Paso,CO,MountainPrevailing
-8043,Fremont,CO,MountainPrevailing
-8045,Garfield,CO,MountainPrevailing
-8047,Gilpin,CO,MountainPrevailing
-8049,Grand,CO,MountainPrevailing
-8051,Gunnison,CO,MountainPrevailing
-8053,Hinsdale,CO,MountainPrevailing
-8055,Huerfano,CO,MountainPrevailing
-8057,Jackson,CO,MountainPrevailing
-8059,Jefferson,CO,MountainPrevailing
-8061,Kiowa,CO,MountainPrevailing
-8063,Kit Carson,CO,MountainPrevailing
-8065,Lake,CO,MountainPrevailing
-8067,La Plata,CO,MountainPrevailing
-8069,Larimer,CO,MountainPrevailing
-8071,Las Animas,CO,MountainPrevailing
-8073,Lincoln,CO,MountainPrevailing
-8075,Logan,CO,MountainPrevailing
-8077,Mesa,CO,MountainPrevailing
-8079,Mineral,CO,MountainPrevailing
-8081,Moffat,CO,MountainPrevailing
-8083,Montezuma,CO,MountainPrevailing
-8085,Montrose,CO,MountainPrevailing
-8087,Morgan,CO,MountainPrevailing
-8089,Otero,CO,MountainPrevailing
-8091,Ouray,CO,MountainPrevailing
-8093,Park,CO,MountainPrevailing
-8095,Phillips,CO,MountainPrevailing
-8097,Pitkin,CO,MountainPrevailing
-8099,Prowers,CO,MountainPrevailing
-8101,Pueblo,CO,MountainPrevailing
-8103,Rio Blanco,CO,MountainPrevailing
-8105,Rio Grande,CO,MountainPrevailing
-8107,Routt,CO,MountainPrevailing
-8109,Saguache,CO,MountainPrevailing
-8111,San Juan,CO,MountainPrevailing
-8113,San Miguel,CO,MountainPrevailing
-8115,Sedgwick,CO,MountainPrevailing
-8117,Summit,CO,MountainPrevailing
-8119,Teller,CO,MountainPrevailing
-8121,Washington,CO,MountainPrevailing
-8123,Weld,CO,MountainPrevailing
-8125,Yuma,CO,MountainPrevailing
-9001,Fairfield,CT,EasternPrevailing
-9003,Hartford,CT,EasternPrevailing
-9005,Litchfield,CT,EasternPrevailing
-9007,Middlesex,CT,EasternPrevailing
-9009,New Haven,CT,EasternPrevailing
-9011,New London,CT,EasternPrevailing
-9013,Tolland,CT,EasternPrevailing
-9015,Windham,CT,EasternPrevailing
+01001,Autauga,AL,CentralPrevailing
+01003,Baldwin,AL,CentralPrevailing
+01005,Barbour,AL,CentralPrevailing
+01007,Bibb,AL,CentralPrevailing
+01009,Blount,AL,CentralPrevailing
+01011,Bullock,AL,CentralPrevailing
+01013,Butler,AL,CentralPrevailing
+01015,Calhoun,AL,CentralPrevailing
+01017,Chambers,AL,CentralPrevailing
+01019,Cherokee,AL,CentralPrevailing
+01021,Chilton,AL,CentralPrevailing
+01023,Choctaw,AL,CentralPrevailing
+01025,Clarke,AL,CentralPrevailing
+01027,Clay,AL,CentralPrevailing
+01029,Cleburne,AL,CentralPrevailing
+01031,Coffee,AL,CentralPrevailing
+01033,Colbert,AL,CentralPrevailing
+01035,Conecuh,AL,CentralPrevailing
+01037,Coosa,AL,CentralPrevailing
+01039,Covington,AL,CentralPrevailing
+01041,Crenshaw,AL,CentralPrevailing
+01043,Cullman,AL,CentralPrevailing
+01045,Dale,AL,CentralPrevailing
+01047,Dallas,AL,CentralPrevailing
+01049,DeKalb,AL,CentralPrevailing
+01051,Elmore,AL,CentralPrevailing
+01053,Escambia,AL,CentralPrevailing
+01055,Etowah,AL,CentralPrevailing
+01057,Fayette,AL,CentralPrevailing
+01059,Franklin,AL,CentralPrevailing
+01061,Geneva,AL,CentralPrevailing
+01063,Greene,AL,CentralPrevailing
+01065,Hale,AL,CentralPrevailing
+01067,Henry,AL,CentralPrevailing
+01069,Houston,AL,CentralPrevailing
+01071,Jackson,AL,CentralPrevailing
+01073,Jefferson,AL,CentralPrevailing
+01075,Lamar,AL,CentralPrevailing
+01077,Lauderdale,AL,CentralPrevailing
+01079,Lawrence,AL,CentralPrevailing
+01081,Lee,AL,CentralPrevailing
+01083,Limestone,AL,CentralPrevailing
+01085,Lowndes,AL,CentralPrevailing
+01087,Macon,AL,CentralPrevailing
+01089,Madison,AL,CentralPrevailing
+01091,Marengo,AL,CentralPrevailing
+01093,Marion,AL,CentralPrevailing
+01095,Marshall,AL,CentralPrevailing
+01097,Mobile,AL,CentralPrevailing
+01099,Monroe,AL,CentralPrevailing
+01101,Montgomery,AL,CentralPrevailing
+01103,Morgan,AL,CentralPrevailing
+01105,Perry,AL,CentralPrevailing
+01107,Pickens,AL,CentralPrevailing
+01109,Pike,AL,CentralPrevailing
+01111,Randolph,AL,CentralPrevailing
+01113,Russell,AL,CentralPrevailing
+01115,St. Clair,AL,CentralPrevailing
+01117,Shelby,AL,CentralPrevailing
+01119,Sumter,AL,CentralPrevailing
+01121,Talladega,AL,CentralPrevailing
+01123,Tallapoosa,AL,CentralPrevailing
+01125,Tuscaloosa,AL,CentralPrevailing
+01127,Walker,AL,CentralPrevailing
+01129,Washington,AL,CentralPrevailing
+01131,Wilcox,AL,CentralPrevailing
+01133,Winston,AL,CentralPrevailing
+04001,Apache,AZ,USArizona
+04003,Cochise,AZ,USArizona
+04005,Coconino,AZ,USArizona
+04007,Gila,AZ,USArizona
+04009,Graham,AZ,USArizona
+04011,Greenlee,AZ,USArizona
+04012,La Paz,AZ,USArizona
+04013,Maricopa,AZ,USArizona
+04015,Mohave,AZ,USArizona
+04017,Navajo,AZ,MountainPrevailing
+04019,Pima,AZ,USArizona
+04021,Pinal,AZ,USArizona
+04023,Santa Cruz,AZ,USArizona
+04025,Yavapai,AZ,USArizona
+04027,Yuma,AZ,USArizona
+05001,Arkansas,AR,CentralPrevailing
+05003,Ashley,AR,CentralPrevailing
+05005,Baxter,AR,CentralPrevailing
+05007,Benton,AR,CentralPrevailing
+05009,Boone,AR,CentralPrevailing
+05011,Bradley,AR,CentralPrevailing
+05013,Calhoun,AR,CentralPrevailing
+05015,Carroll,AR,CentralPrevailing
+05017,Chicot,AR,CentralPrevailing
+05019,Clark,AR,CentralPrevailing
+05021,Clay,AR,CentralPrevailing
+05023,Cleburne,AR,CentralPrevailing
+05025,Cleveland,AR,CentralPrevailing
+05027,Columbia,AR,CentralPrevailing
+05029,Conway,AR,CentralPrevailing
+05031,Craighead,AR,CentralPrevailing
+05033,Crawford,AR,CentralPrevailing
+05035,Crittenden,AR,CentralPrevailing
+05037,Cross,AR,CentralPrevailing
+05039,Dallas,AR,CentralPrevailing
+05041,Desha,AR,CentralPrevailing
+05043,Drew,AR,CentralPrevailing
+05045,Faulkner,AR,CentralPrevailing
+05047,Franklin,AR,CentralPrevailing
+05049,Fulton,AR,CentralPrevailing
+05051,Garland,AR,CentralPrevailing
+05053,Grant,AR,CentralPrevailing
+05055,Greene,AR,CentralPrevailing
+05057,Hempstead,AR,CentralPrevailing
+05059,Hot Spring,AR,CentralPrevailing
+05061,Howard,AR,CentralPrevailing
+05063,Independence,AR,CentralPrevailing
+05065,Izard,AR,CentralPrevailing
+05067,Jackson,AR,CentralPrevailing
+05069,Jefferson,AR,CentralPrevailing
+05071,Johnson,AR,CentralPrevailing
+05073,Lafayette,AR,CentralPrevailing
+05075,Lawrence,AR,CentralPrevailing
+05077,Lee,AR,CentralPrevailing
+05079,Lincoln,AR,CentralPrevailing
+05081,Little River,AR,CentralPrevailing
+05083,Logan,AR,CentralPrevailing
+05085,Lonoke,AR,CentralPrevailing
+05087,Madison,AR,CentralPrevailing
+05089,Marion,AR,CentralPrevailing
+05091,Miller,AR,CentralPrevailing
+05093,Mississippi,AR,CentralPrevailing
+05095,Monroe,AR,CentralPrevailing
+05097,Montgomery,AR,CentralPrevailing
+05099,Nevada,AR,CentralPrevailing
+05101,Newton,AR,CentralPrevailing
+05103,Ouachita,AR,CentralPrevailing
+05105,Perry,AR,CentralPrevailing
+05107,Phillips,AR,CentralPrevailing
+05109,Pike,AR,CentralPrevailing
+05111,Poinsett,AR,CentralPrevailing
+05113,Polk,AR,CentralPrevailing
+05115,Pope,AR,CentralPrevailing
+05117,Prairie,AR,CentralPrevailing
+05119,Pulaski,AR,CentralPrevailing
+05121,Randolph,AR,CentralPrevailing
+05123,St. Francis,AR,CentralPrevailing
+05125,Saline,AR,CentralPrevailing
+05127,Scott,AR,CentralPrevailing
+05129,Searcy,AR,CentralPrevailing
+05131,Sebastian,AR,CentralPrevailing
+05133,Sevier,AR,CentralPrevailing
+05135,Sharp,AR,CentralPrevailing
+05137,Stone,AR,CentralPrevailing
+05139,Union,AR,CentralPrevailing
+05141,Van Buren,AR,CentralPrevailing
+05143,Washington,AR,CentralPrevailing
+05145,White,AR,CentralPrevailing
+05147,Woodruff,AR,CentralPrevailing
+05149,Yell,AR,CentralPrevailing
+06001,Alameda,CA,PacificPrevailing
+06003,Alpine,CA,PacificPrevailing
+06005,Amador,CA,PacificPrevailing
+06007,Butte,CA,PacificPrevailing
+06009,Calaveras,CA,PacificPrevailing
+06011,Colusa,CA,PacificPrevailing
+06013,Contra Costa,CA,PacificPrevailing
+06015,Del Norte,CA,PacificPrevailing
+06017,El Dorado,CA,PacificPrevailing
+06019,Fresno,CA,PacificPrevailing
+06021,Glenn,CA,PacificPrevailing
+06023,Humboldt,CA,PacificPrevailing
+06025,Imperial,CA,PacificPrevailing
+06027,Inyo,CA,PacificPrevailing
+06029,Kern,CA,PacificPrevailing
+06031,Kings,CA,PacificPrevailing
+06033,Lake,CA,PacificPrevailing
+06035,Lassen,CA,PacificPrevailing
+06037,Los Angeles,CA,PacificPrevailing
+06039,Madera,CA,PacificPrevailing
+06041,Marin,CA,PacificPrevailing
+06043,Mariposa,CA,PacificPrevailing
+06045,Mendocino,CA,PacificPrevailing
+06047,Merced,CA,PacificPrevailing
+06049,Modoc,CA,PacificPrevailing
+06051,Mono,CA,PacificPrevailing
+06053,Monterey,CA,PacificPrevailing
+06055,Napa,CA,PacificPrevailing
+06057,Nevada,CA,PacificPrevailing
+06059,Orange,CA,PacificPrevailing
+06061,Placer,CA,PacificPrevailing
+06063,Plumas,CA,PacificPrevailing
+06065,Riverside,CA,PacificPrevailing
+06067,Sacramento,CA,PacificPrevailing
+06069,San Benito,CA,PacificPrevailing
+06071,San Bernardino,CA,PacificPrevailing
+06073,San Diego,CA,PacificPrevailing
+06075,San Francisco,CA,PacificPrevailing
+06077,San Joaquin,CA,PacificPrevailing
+06079,San Luis Obispo,CA,PacificPrevailing
+06081,San Mateo,CA,PacificPrevailing
+06083,Santa Barbara,CA,PacificPrevailing
+06085,Santa Clara,CA,PacificPrevailing
+06087,Santa Cruz,CA,PacificPrevailing
+06089,Shasta,CA,PacificPrevailing
+06091,Sierra,CA,PacificPrevailing
+06093,Siskiyou,CA,PacificPrevailing
+06095,Solano,CA,PacificPrevailing
+06097,Sonoma,CA,PacificPrevailing
+06099,Stanislaus,CA,PacificPrevailing
+06101,Sutter,CA,PacificPrevailing
+06103,Tehama,CA,PacificPrevailing
+06105,Trinity,CA,PacificPrevailing
+06107,Tulare,CA,PacificPrevailing
+06109,Tuolumne,CA,PacificPrevailing
+06111,Ventura,CA,PacificPrevailing
+06113,Yolo,CA,PacificPrevailing
+06115,Yuba,CA,PacificPrevailing
+08001,Adams,CO,MountainPrevailing
+08003,Alamosa,CO,MountainPrevailing
+08005,Arapahoe,CO,MountainPrevailing
+08007,Archuleta,CO,MountainPrevailing
+08009,Baca,CO,MountainPrevailing
+08011,Bent,CO,MountainPrevailing
+08013,Boulder,CO,MountainPrevailing
+08014,Broomfield,CO,MountainPrevailing
+08015,Chaffee,CO,MountainPrevailing
+08017,Cheyenne,CO,MountainPrevailing
+08019,Clear Creek,CO,MountainPrevailing
+08021,Conejos,CO,MountainPrevailing
+08023,Costilla,CO,MountainPrevailing
+08025,Crowley,CO,MountainPrevailing
+08027,Custer,CO,MountainPrevailing
+08029,Delta,CO,MountainPrevailing
+08031,Denver,CO,MountainPrevailing
+08033,Dolores,CO,MountainPrevailing
+08035,Douglas,CO,MountainPrevailing
+08037,Eagle,CO,MountainPrevailing
+08039,Elbert,CO,MountainPrevailing
+08041,El Paso,CO,MountainPrevailing
+08043,Fremont,CO,MountainPrevailing
+08045,Garfield,CO,MountainPrevailing
+08047,Gilpin,CO,MountainPrevailing
+08049,Grand,CO,MountainPrevailing
+08051,Gunnison,CO,MountainPrevailing
+08053,Hinsdale,CO,MountainPrevailing
+08055,Huerfano,CO,MountainPrevailing
+08057,Jackson,CO,MountainPrevailing
+08059,Jefferson,CO,MountainPrevailing
+08061,Kiowa,CO,MountainPrevailing
+08063,Kit Carson,CO,MountainPrevailing
+08065,Lake,CO,MountainPrevailing
+08067,La Plata,CO,MountainPrevailing
+08069,Larimer,CO,MountainPrevailing
+08071,Las Animas,CO,MountainPrevailing
+08073,Lincoln,CO,MountainPrevailing
+08075,Logan,CO,MountainPrevailing
+08077,Mesa,CO,MountainPrevailing
+08079,Mineral,CO,MountainPrevailing
+08081,Moffat,CO,MountainPrevailing
+08083,Montezuma,CO,MountainPrevailing
+08085,Montrose,CO,MountainPrevailing
+08087,Morgan,CO,MountainPrevailing
+08089,Otero,CO,MountainPrevailing
+08091,Ouray,CO,MountainPrevailing
+08093,Park,CO,MountainPrevailing
+08095,Phillips,CO,MountainPrevailing
+08097,Pitkin,CO,MountainPrevailing
+08099,Prowers,CO,MountainPrevailing
+08101,Pueblo,CO,MountainPrevailing
+08103,Rio Blanco,CO,MountainPrevailing
+08105,Rio Grande,CO,MountainPrevailing
+08107,Routt,CO,MountainPrevailing
+08109,Saguache,CO,MountainPrevailing
+08111,San Juan,CO,MountainPrevailing
+08113,San Miguel,CO,MountainPrevailing
+08115,Sedgwick,CO,MountainPrevailing
+08117,Summit,CO,MountainPrevailing
+08119,Teller,CO,MountainPrevailing
+08121,Washington,CO,MountainPrevailing
+08123,Weld,CO,MountainPrevailing
+08125,Yuma,CO,MountainPrevailing
+09001,Fairfield,CT,EasternPrevailing
+09003,Hartford,CT,EasternPrevailing
+09005,Litchfield,CT,EasternPrevailing
+09007,Middlesex,CT,EasternPrevailing
+09009,New Haven,CT,EasternPrevailing
+09011,New London,CT,EasternPrevailing
+09013,Tolland,CT,EasternPrevailing
+09015,Windham,CT,EasternPrevailing
 10001,Kent,DE,EasternPrevailing
 10003,New Castle,DE,EasternPrevailing
 10005,Sussex,DE,EasternPrevailing
@@ -1981,7 +1981,7 @@ id,name,state,time_zone
 38047,Logan,ND,CentralPrevailing
 38049,McHenry,ND,CentralPrevailing
 38051,McIntosh,ND,CentralPrevailing
-38053,McKenzie,ND,CentralPrevailing
+38053,McKenzie,ND,MountainPrevailing
 38055,McLean,ND,CentralPrevailing
 38057,Mercer,ND,CentralPrevailing
 38059,Morton,ND,CentralPrevailing
@@ -2329,62 +2329,62 @@ id,name,state,time_zone
 45091,York,SC,EasternPrevailing
 46003,Aurora,SD,CentralPrevailing
 46005,Beadle,SD,CentralPrevailing
-46007,Bennett,SD,EasternPrevailing
+46007,Bennett,SD,MountainPrevailing
 46009,Bon Homme,SD,CentralPrevailing
 46011,Brookings,SD,CentralPrevailing
 46013,Brown,SD,CentralPrevailing
 46015,Brule,SD,CentralPrevailing
 46017,Buffalo,SD,CentralPrevailing
-46019,Butte,SD,EasternPrevailing
+46019,Butte,SD,MountainPrevailing
 46021,Campbell,SD,CentralPrevailing
 46023,Charles Mix,SD,CentralPrevailing
 46025,Clark,SD,CentralPrevailing
 46027,Clay,SD,CentralPrevailing
 46029,Codington,SD,CentralPrevailing
-46031,Corson,SD,EasternPrevailing
-46033,Custer,SD,EasternPrevailing
+46031,Corson,SD,MountainPrevailing
+46033,Custer,SD,MountainPrevailing
 46035,Davison,SD,CentralPrevailing
 46037,Day,SD,CentralPrevailing
 46039,Deuel,SD,CentralPrevailing
-46041,Dewey,SD,EasternPrevailing
+46041,Dewey,SD,MountainPrevailing
 46043,Douglas,SD,CentralPrevailing
 46045,Edmunds,SD,CentralPrevailing
-46047,Fall River,SD,EasternPrevailing
+46047,Fall River,SD,MountainPrevailing
 46049,Faulk,SD,CentralPrevailing
 46051,Grant,SD,CentralPrevailing
 46053,Gregory,SD,CentralPrevailing
-46055,Haakon,SD,EasternPrevailing
+46055,Haakon,SD,MountainPrevailing
 46057,Hamlin,SD,CentralPrevailing
 46059,Hand,SD,CentralPrevailing
 46061,Hanson,SD,CentralPrevailing
-46063,Harding,SD,EasternPrevailing
+46063,Harding,SD,MountainPrevailing
 46065,Hughes,SD,CentralPrevailing
 46067,Hutchinson,SD,CentralPrevailing
 46069,Hyde,SD,CentralPrevailing
-46071,Jackson,SD,EasternPrevailing
+46071,Jackson,SD,MountainPrevailing
 46073,Jerauld,SD,CentralPrevailing
 46075,Jones,SD,CentralPrevailing
 46077,Kingsbury,SD,CentralPrevailing
 46079,Lake,SD,CentralPrevailing
-46081,Lawrence,SD,EasternPrevailing
+46081,Lawrence,SD,MountainPrevailing
 46083,Lincoln,SD,CentralPrevailing
 46085,Lyman,SD,CentralPrevailing
 46087,McCook,SD,CentralPrevailing
 46089,McPherson,SD,CentralPrevailing
 46091,Marshall,SD,CentralPrevailing
-46093,Meade,SD,EasternPrevailing
+46093,Meade,SD,MountainPrevailing
 46095,Mellette,SD,CentralPrevailing
 46097,Miner,SD,CentralPrevailing
 46099,Minnehaha,SD,CentralPrevailing
 46101,Moody,SD,CentralPrevailing
-46102,Oglala Lakota,SD,CentralPrevailing
-46103,Pennington,SD,EasternPrevailing
-46105,Perkins,SD,EasternPrevailing
+46102,Oglala Lakota,SD,MountainPrevailing
+46103,Pennington,SD,MountainPrevailing
+46105,Perkins,SD,MountainPrevailing
 46107,Potter,SD,CentralPrevailing
 46109,Roberts,SD,CentralPrevailing
 46111,Sanborn,SD,CentralPrevailing
 46115,Spink,SD,CentralPrevailing
-46117,Stanley,SD,CentralPrevailing
+46117,Stanley,SD,MountainPrevailing
 46119,Sully,SD,CentralPrevailing
 46121,Todd,SD,CentralPrevailing
 46123,Tripp,SD,CentralPrevailing

--- a/tempo_project/dimensions/counties.csv
+++ b/tempo_project/dimensions/counties.csv
@@ -1,291 +1,291 @@
 id,name,state,time_zone
-01001,Autauga,AL,CentralPrevailing
-01003,Baldwin,AL,CentralPrevailing
-01005,Barbour,AL,CentralPrevailing
-01007,Bibb,AL,CentralPrevailing
-01009,Blount,AL,CentralPrevailing
-01011,Bullock,AL,CentralPrevailing
-01013,Butler,AL,CentralPrevailing
-01015,Calhoun,AL,CentralPrevailing
-01017,Chambers,AL,CentralPrevailing
-01019,Cherokee,AL,CentralPrevailing
-01021,Chilton,AL,CentralPrevailing
-01023,Choctaw,AL,CentralPrevailing
-01025,Clarke,AL,CentralPrevailing
-01027,Clay,AL,CentralPrevailing
-01029,Cleburne,AL,CentralPrevailing
-01031,Coffee,AL,CentralPrevailing
-01033,Colbert,AL,CentralPrevailing
-01035,Conecuh,AL,CentralPrevailing
-01037,Coosa,AL,CentralPrevailing
-01039,Covington,AL,CentralPrevailing
-01041,Crenshaw,AL,CentralPrevailing
-01043,Cullman,AL,CentralPrevailing
-01045,Dale,AL,CentralPrevailing
-01047,Dallas,AL,CentralPrevailing
-01049,DeKalb,AL,CentralPrevailing
-01051,Elmore,AL,CentralPrevailing
-01053,Escambia,AL,CentralPrevailing
-01055,Etowah,AL,CentralPrevailing
-01057,Fayette,AL,CentralPrevailing
-01059,Franklin,AL,CentralPrevailing
-01061,Geneva,AL,CentralPrevailing
-01063,Greene,AL,CentralPrevailing
-01065,Hale,AL,CentralPrevailing
-01067,Henry,AL,CentralPrevailing
-01069,Houston,AL,CentralPrevailing
-01071,Jackson,AL,CentralPrevailing
-01073,Jefferson,AL,CentralPrevailing
-01075,Lamar,AL,CentralPrevailing
-01077,Lauderdale,AL,CentralPrevailing
-01079,Lawrence,AL,CentralPrevailing
-01081,Lee,AL,CentralPrevailing
-01083,Limestone,AL,CentralPrevailing
-01085,Lowndes,AL,CentralPrevailing
-01087,Macon,AL,CentralPrevailing
-01089,Madison,AL,CentralPrevailing
-01091,Marengo,AL,CentralPrevailing
-01093,Marion,AL,CentralPrevailing
-01095,Marshall,AL,CentralPrevailing
-01097,Mobile,AL,CentralPrevailing
-01099,Monroe,AL,CentralPrevailing
-01101,Montgomery,AL,CentralPrevailing
-01103,Morgan,AL,CentralPrevailing
-01105,Perry,AL,CentralPrevailing
-01107,Pickens,AL,CentralPrevailing
-01109,Pike,AL,CentralPrevailing
-01111,Randolph,AL,CentralPrevailing
-01113,Russell,AL,CentralPrevailing
-01115,St. Clair,AL,CentralPrevailing
-01117,Shelby,AL,CentralPrevailing
-01119,Sumter,AL,CentralPrevailing
-01121,Talladega,AL,CentralPrevailing
-01123,Tallapoosa,AL,CentralPrevailing
-01125,Tuscaloosa,AL,CentralPrevailing
-01127,Walker,AL,CentralPrevailing
-01129,Washington,AL,CentralPrevailing
-01131,Wilcox,AL,CentralPrevailing
-01133,Winston,AL,CentralPrevailing
-04001,Apache,AZ,MountainStandard
-04003,Cochise,AZ,MountainStandard
-04005,Coconino,AZ,MountainStandard
-04007,Gila,AZ,MountainStandard
-04009,Graham,AZ,MountainStandard
-04011,Greenlee,AZ,MountainStandard
-04012,La Paz,AZ,MountainStandard
-04013,Maricopa,AZ,MountainStandard
-04015,Mohave,AZ,MountainStandard
-04017,Navajo,AZ,MountainPrevailing
-04019,Pima,AZ,MountainStandard
-04021,Pinal,AZ,MountainStandard
-04023,Santa Cruz,AZ,MountainStandard
-04025,Yavapai,AZ,MountainStandard
-04027,Yuma,AZ,MountainStandard
-05001,Arkansas,AR,CentralPrevailing
-05003,Ashley,AR,CentralPrevailing
-05005,Baxter,AR,CentralPrevailing
-05007,Benton,AR,CentralPrevailing
-05009,Boone,AR,CentralPrevailing
-05011,Bradley,AR,CentralPrevailing
-05013,Calhoun,AR,CentralPrevailing
-05015,Carroll,AR,CentralPrevailing
-05017,Chicot,AR,CentralPrevailing
-05019,Clark,AR,CentralPrevailing
-05021,Clay,AR,CentralPrevailing
-05023,Cleburne,AR,CentralPrevailing
-05025,Cleveland,AR,CentralPrevailing
-05027,Columbia,AR,CentralPrevailing
-05029,Conway,AR,CentralPrevailing
-05031,Craighead,AR,CentralPrevailing
-05033,Crawford,AR,CentralPrevailing
-05035,Crittenden,AR,CentralPrevailing
-05037,Cross,AR,CentralPrevailing
-05039,Dallas,AR,CentralPrevailing
-05041,Desha,AR,CentralPrevailing
-05043,Drew,AR,CentralPrevailing
-05045,Faulkner,AR,CentralPrevailing
-05047,Franklin,AR,CentralPrevailing
-05049,Fulton,AR,CentralPrevailing
-05051,Garland,AR,CentralPrevailing
-05053,Grant,AR,CentralPrevailing
-05055,Greene,AR,CentralPrevailing
-05057,Hempstead,AR,CentralPrevailing
-05059,Hot Spring,AR,CentralPrevailing
-05061,Howard,AR,CentralPrevailing
-05063,Independence,AR,CentralPrevailing
-05065,Izard,AR,CentralPrevailing
-05067,Jackson,AR,CentralPrevailing
-05069,Jefferson,AR,CentralPrevailing
-05071,Johnson,AR,CentralPrevailing
-05073,Lafayette,AR,CentralPrevailing
-05075,Lawrence,AR,CentralPrevailing
-05077,Lee,AR,CentralPrevailing
-05079,Lincoln,AR,CentralPrevailing
-05081,Little River,AR,CentralPrevailing
-05083,Logan,AR,CentralPrevailing
-05085,Lonoke,AR,CentralPrevailing
-05087,Madison,AR,CentralPrevailing
-05089,Marion,AR,CentralPrevailing
-05091,Miller,AR,CentralPrevailing
-05093,Mississippi,AR,CentralPrevailing
-05095,Monroe,AR,CentralPrevailing
-05097,Montgomery,AR,CentralPrevailing
-05099,Nevada,AR,CentralPrevailing
-05101,Newton,AR,CentralPrevailing
-05103,Ouachita,AR,CentralPrevailing
-05105,Perry,AR,CentralPrevailing
-05107,Phillips,AR,CentralPrevailing
-05109,Pike,AR,CentralPrevailing
-05111,Poinsett,AR,CentralPrevailing
-05113,Polk,AR,CentralPrevailing
-05115,Pope,AR,CentralPrevailing
-05117,Prairie,AR,CentralPrevailing
-05119,Pulaski,AR,CentralPrevailing
-05121,Randolph,AR,CentralPrevailing
-05123,St. Francis,AR,CentralPrevailing
-05125,Saline,AR,CentralPrevailing
-05127,Scott,AR,CentralPrevailing
-05129,Searcy,AR,CentralPrevailing
-05131,Sebastian,AR,CentralPrevailing
-05133,Sevier,AR,CentralPrevailing
-05135,Sharp,AR,CentralPrevailing
-05137,Stone,AR,CentralPrevailing
-05139,Union,AR,CentralPrevailing
-05141,Van Buren,AR,CentralPrevailing
-05143,Washington,AR,CentralPrevailing
-05145,White,AR,CentralPrevailing
-05147,Woodruff,AR,CentralPrevailing
-05149,Yell,AR,CentralPrevailing
-06001,Alameda,CA,PacificPrevailing
-06003,Alpine,CA,PacificPrevailing
-06005,Amador,CA,PacificPrevailing
-06007,Butte,CA,PacificPrevailing
-06009,Calaveras,CA,PacificPrevailing
-06011,Colusa,CA,PacificPrevailing
-06013,Contra Costa,CA,PacificPrevailing
-06015,Del Norte,CA,PacificPrevailing
-06017,El Dorado,CA,PacificPrevailing
-06019,Fresno,CA,PacificPrevailing
-06021,Glenn,CA,PacificPrevailing
-06023,Humboldt,CA,PacificPrevailing
-06025,Imperial,CA,PacificPrevailing
-06027,Inyo,CA,PacificPrevailing
-06029,Kern,CA,PacificPrevailing
-06031,Kings,CA,PacificPrevailing
-06033,Lake,CA,PacificPrevailing
-06035,Lassen,CA,PacificPrevailing
-06037,Los Angeles,CA,PacificPrevailing
-06039,Madera,CA,PacificPrevailing
-06041,Marin,CA,PacificPrevailing
-06043,Mariposa,CA,PacificPrevailing
-06045,Mendocino,CA,PacificPrevailing
-06047,Merced,CA,PacificPrevailing
-06049,Modoc,CA,PacificPrevailing
-06051,Mono,CA,PacificPrevailing
-06053,Monterey,CA,PacificPrevailing
-06055,Napa,CA,PacificPrevailing
-06057,Nevada,CA,PacificPrevailing
-06059,Orange,CA,PacificPrevailing
-06061,Placer,CA,PacificPrevailing
-06063,Plumas,CA,PacificPrevailing
-06065,Riverside,CA,PacificPrevailing
-06067,Sacramento,CA,PacificPrevailing
-06069,San Benito,CA,PacificPrevailing
-06071,San Bernardino,CA,PacificPrevailing
-06073,San Diego,CA,PacificPrevailing
-06075,San Francisco,CA,PacificPrevailing
-06077,San Joaquin,CA,PacificPrevailing
-06079,San Luis Obispo,CA,PacificPrevailing
-06081,San Mateo,CA,PacificPrevailing
-06083,Santa Barbara,CA,PacificPrevailing
-06085,Santa Clara,CA,PacificPrevailing
-06087,Santa Cruz,CA,PacificPrevailing
-06089,Shasta,CA,PacificPrevailing
-06091,Sierra,CA,PacificPrevailing
-06093,Siskiyou,CA,PacificPrevailing
-06095,Solano,CA,PacificPrevailing
-06097,Sonoma,CA,PacificPrevailing
-06099,Stanislaus,CA,PacificPrevailing
-06101,Sutter,CA,PacificPrevailing
-06103,Tehama,CA,PacificPrevailing
-06105,Trinity,CA,PacificPrevailing
-06107,Tulare,CA,PacificPrevailing
-06109,Tuolumne,CA,PacificPrevailing
-06111,Ventura,CA,PacificPrevailing
-06113,Yolo,CA,PacificPrevailing
-06115,Yuba,CA,PacificPrevailing
-08001,Adams,CO,MountainPrevailing
-08003,Alamosa,CO,MountainPrevailing
-08005,Arapahoe,CO,MountainPrevailing
-08007,Archuleta,CO,MountainPrevailing
-08009,Baca,CO,MountainPrevailing
-08011,Bent,CO,MountainPrevailing
-08013,Boulder,CO,MountainPrevailing
-08014,Broomfield,CO,MountainPrevailing
-08015,Chaffee,CO,MountainPrevailing
-08017,Cheyenne,CO,MountainPrevailing
-08019,Clear Creek,CO,MountainPrevailing
-08021,Conejos,CO,MountainPrevailing
-08023,Costilla,CO,MountainPrevailing
-08025,Crowley,CO,MountainPrevailing
-08027,Custer,CO,MountainPrevailing
-08029,Delta,CO,MountainPrevailing
-08031,Denver,CO,MountainPrevailing
-08033,Dolores,CO,MountainPrevailing
-08035,Douglas,CO,MountainPrevailing
-08037,Eagle,CO,MountainPrevailing
-08039,Elbert,CO,MountainPrevailing
-08041,El Paso,CO,MountainPrevailing
-08043,Fremont,CO,MountainPrevailing
-08045,Garfield,CO,MountainPrevailing
-08047,Gilpin,CO,MountainPrevailing
-08049,Grand,CO,MountainPrevailing
-08051,Gunnison,CO,MountainPrevailing
-08053,Hinsdale,CO,MountainPrevailing
-08055,Huerfano,CO,MountainPrevailing
-08057,Jackson,CO,MountainPrevailing
-08059,Jefferson,CO,MountainPrevailing
-08061,Kiowa,CO,MountainPrevailing
-08063,Kit Carson,CO,MountainPrevailing
-08065,Lake,CO,MountainPrevailing
-08067,La Plata,CO,MountainPrevailing
-08069,Larimer,CO,MountainPrevailing
-08071,Las Animas,CO,MountainPrevailing
-08073,Lincoln,CO,MountainPrevailing
-08075,Logan,CO,MountainPrevailing
-08077,Mesa,CO,MountainPrevailing
-08079,Mineral,CO,MountainPrevailing
-08081,Moffat,CO,MountainPrevailing
-08083,Montezuma,CO,MountainPrevailing
-08085,Montrose,CO,MountainPrevailing
-08087,Morgan,CO,MountainPrevailing
-08089,Otero,CO,MountainPrevailing
-08091,Ouray,CO,MountainPrevailing
-08093,Park,CO,MountainPrevailing
-08095,Phillips,CO,MountainPrevailing
-08097,Pitkin,CO,MountainPrevailing
-08099,Prowers,CO,MountainPrevailing
-08101,Pueblo,CO,MountainPrevailing
-08103,Rio Blanco,CO,MountainPrevailing
-08105,Rio Grande,CO,MountainPrevailing
-08107,Routt,CO,MountainPrevailing
-08109,Saguache,CO,MountainPrevailing
-08111,San Juan,CO,MountainPrevailing
-08113,San Miguel,CO,MountainPrevailing
-08115,Sedgwick,CO,MountainPrevailing
-08117,Summit,CO,MountainPrevailing
-08119,Teller,CO,MountainPrevailing
-08121,Washington,CO,MountainPrevailing
-08123,Weld,CO,MountainPrevailing
-08125,Yuma,CO,MountainPrevailing
-09001,Fairfield,CT,EasternPrevailing
-09003,Hartford,CT,EasternPrevailing
-09005,Litchfield,CT,EasternPrevailing
-09007,Middlesex,CT,EasternPrevailing
-09009,New Haven,CT,EasternPrevailing
-09011,New London,CT,EasternPrevailing
-09013,Tolland,CT,EasternPrevailing
-09015,Windham,CT,EasternPrevailing
+1001,Autauga,AL,CentralPrevailing
+1003,Baldwin,AL,CentralPrevailing
+1005,Barbour,AL,CentralPrevailing
+1007,Bibb,AL,CentralPrevailing
+1009,Blount,AL,CentralPrevailing
+1011,Bullock,AL,CentralPrevailing
+1013,Butler,AL,CentralPrevailing
+1015,Calhoun,AL,CentralPrevailing
+1017,Chambers,AL,CentralPrevailing
+1019,Cherokee,AL,CentralPrevailing
+1021,Chilton,AL,CentralPrevailing
+1023,Choctaw,AL,CentralPrevailing
+1025,Clarke,AL,CentralPrevailing
+1027,Clay,AL,CentralPrevailing
+1029,Cleburne,AL,CentralPrevailing
+1031,Coffee,AL,CentralPrevailing
+1033,Colbert,AL,CentralPrevailing
+1035,Conecuh,AL,CentralPrevailing
+1037,Coosa,AL,CentralPrevailing
+1039,Covington,AL,CentralPrevailing
+1041,Crenshaw,AL,CentralPrevailing
+1043,Cullman,AL,CentralPrevailing
+1045,Dale,AL,CentralPrevailing
+1047,Dallas,AL,CentralPrevailing
+1049,DeKalb,AL,CentralPrevailing
+1051,Elmore,AL,CentralPrevailing
+1053,Escambia,AL,CentralPrevailing
+1055,Etowah,AL,CentralPrevailing
+1057,Fayette,AL,CentralPrevailing
+1059,Franklin,AL,CentralPrevailing
+1061,Geneva,AL,CentralPrevailing
+1063,Greene,AL,CentralPrevailing
+1065,Hale,AL,CentralPrevailing
+1067,Henry,AL,CentralPrevailing
+1069,Houston,AL,CentralPrevailing
+1071,Jackson,AL,CentralPrevailing
+1073,Jefferson,AL,CentralPrevailing
+1075,Lamar,AL,CentralPrevailing
+1077,Lauderdale,AL,CentralPrevailing
+1079,Lawrence,AL,CentralPrevailing
+1081,Lee,AL,CentralPrevailing
+1083,Limestone,AL,CentralPrevailing
+1085,Lowndes,AL,CentralPrevailing
+1087,Macon,AL,CentralPrevailing
+1089,Madison,AL,CentralPrevailing
+1091,Marengo,AL,CentralPrevailing
+1093,Marion,AL,CentralPrevailing
+1095,Marshall,AL,CentralPrevailing
+1097,Mobile,AL,CentralPrevailing
+1099,Monroe,AL,CentralPrevailing
+1101,Montgomery,AL,CentralPrevailing
+1103,Morgan,AL,CentralPrevailing
+1105,Perry,AL,CentralPrevailing
+1107,Pickens,AL,CentralPrevailing
+1109,Pike,AL,CentralPrevailing
+1111,Randolph,AL,CentralPrevailing
+1113,Russell,AL,CentralPrevailing
+1115,St. Clair,AL,CentralPrevailing
+1117,Shelby,AL,CentralPrevailing
+1119,Sumter,AL,CentralPrevailing
+1121,Talladega,AL,CentralPrevailing
+1123,Tallapoosa,AL,CentralPrevailing
+1125,Tuscaloosa,AL,CentralPrevailing
+1127,Walker,AL,CentralPrevailing
+1129,Washington,AL,CentralPrevailing
+1131,Wilcox,AL,CentralPrevailing
+1133,Winston,AL,CentralPrevailing
+4001,Apache,AZ,MountainStandard
+4003,Cochise,AZ,MountainStandard
+4005,Coconino,AZ,MountainStandard
+4007,Gila,AZ,MountainStandard
+4009,Graham,AZ,MountainStandard
+4011,Greenlee,AZ,MountainStandard
+4012,La Paz,AZ,MountainStandard
+4013,Maricopa,AZ,MountainStandard
+4015,Mohave,AZ,MountainStandard
+4017,Navajo,AZ,MountainPrevailing
+4019,Pima,AZ,MountainStandard
+4021,Pinal,AZ,MountainStandard
+4023,Santa Cruz,AZ,MountainStandard
+4025,Yavapai,AZ,MountainStandard
+4027,Yuma,AZ,MountainStandard
+5001,Arkansas,AR,CentralPrevailing
+5003,Ashley,AR,CentralPrevailing
+5005,Baxter,AR,CentralPrevailing
+5007,Benton,AR,CentralPrevailing
+5009,Boone,AR,CentralPrevailing
+5011,Bradley,AR,CentralPrevailing
+5013,Calhoun,AR,CentralPrevailing
+5015,Carroll,AR,CentralPrevailing
+5017,Chicot,AR,CentralPrevailing
+5019,Clark,AR,CentralPrevailing
+5021,Clay,AR,CentralPrevailing
+5023,Cleburne,AR,CentralPrevailing
+5025,Cleveland,AR,CentralPrevailing
+5027,Columbia,AR,CentralPrevailing
+5029,Conway,AR,CentralPrevailing
+5031,Craighead,AR,CentralPrevailing
+5033,Crawford,AR,CentralPrevailing
+5035,Crittenden,AR,CentralPrevailing
+5037,Cross,AR,CentralPrevailing
+5039,Dallas,AR,CentralPrevailing
+5041,Desha,AR,CentralPrevailing
+5043,Drew,AR,CentralPrevailing
+5045,Faulkner,AR,CentralPrevailing
+5047,Franklin,AR,CentralPrevailing
+5049,Fulton,AR,CentralPrevailing
+5051,Garland,AR,CentralPrevailing
+5053,Grant,AR,CentralPrevailing
+5055,Greene,AR,CentralPrevailing
+5057,Hempstead,AR,CentralPrevailing
+5059,Hot Spring,AR,CentralPrevailing
+5061,Howard,AR,CentralPrevailing
+5063,Independence,AR,CentralPrevailing
+5065,Izard,AR,CentralPrevailing
+5067,Jackson,AR,CentralPrevailing
+5069,Jefferson,AR,CentralPrevailing
+5071,Johnson,AR,CentralPrevailing
+5073,Lafayette,AR,CentralPrevailing
+5075,Lawrence,AR,CentralPrevailing
+5077,Lee,AR,CentralPrevailing
+5079,Lincoln,AR,CentralPrevailing
+5081,Little River,AR,CentralPrevailing
+5083,Logan,AR,CentralPrevailing
+5085,Lonoke,AR,CentralPrevailing
+5087,Madison,AR,CentralPrevailing
+5089,Marion,AR,CentralPrevailing
+5091,Miller,AR,CentralPrevailing
+5093,Mississippi,AR,CentralPrevailing
+5095,Monroe,AR,CentralPrevailing
+5097,Montgomery,AR,CentralPrevailing
+5099,Nevada,AR,CentralPrevailing
+5101,Newton,AR,CentralPrevailing
+5103,Ouachita,AR,CentralPrevailing
+5105,Perry,AR,CentralPrevailing
+5107,Phillips,AR,CentralPrevailing
+5109,Pike,AR,CentralPrevailing
+5111,Poinsett,AR,CentralPrevailing
+5113,Polk,AR,CentralPrevailing
+5115,Pope,AR,CentralPrevailing
+5117,Prairie,AR,CentralPrevailing
+5119,Pulaski,AR,CentralPrevailing
+5121,Randolph,AR,CentralPrevailing
+5123,St. Francis,AR,CentralPrevailing
+5125,Saline,AR,CentralPrevailing
+5127,Scott,AR,CentralPrevailing
+5129,Searcy,AR,CentralPrevailing
+5131,Sebastian,AR,CentralPrevailing
+5133,Sevier,AR,CentralPrevailing
+5135,Sharp,AR,CentralPrevailing
+5137,Stone,AR,CentralPrevailing
+5139,Union,AR,CentralPrevailing
+5141,Van Buren,AR,CentralPrevailing
+5143,Washington,AR,CentralPrevailing
+5145,White,AR,CentralPrevailing
+5147,Woodruff,AR,CentralPrevailing
+5149,Yell,AR,CentralPrevailing
+6001,Alameda,CA,PacificPrevailing
+6003,Alpine,CA,PacificPrevailing
+6005,Amador,CA,PacificPrevailing
+6007,Butte,CA,PacificPrevailing
+6009,Calaveras,CA,PacificPrevailing
+6011,Colusa,CA,PacificPrevailing
+6013,Contra Costa,CA,PacificPrevailing
+6015,Del Norte,CA,PacificPrevailing
+6017,El Dorado,CA,PacificPrevailing
+6019,Fresno,CA,PacificPrevailing
+6021,Glenn,CA,PacificPrevailing
+6023,Humboldt,CA,PacificPrevailing
+6025,Imperial,CA,PacificPrevailing
+6027,Inyo,CA,PacificPrevailing
+6029,Kern,CA,PacificPrevailing
+6031,Kings,CA,PacificPrevailing
+6033,Lake,CA,PacificPrevailing
+6035,Lassen,CA,PacificPrevailing
+6037,Los Angeles,CA,PacificPrevailing
+6039,Madera,CA,PacificPrevailing
+6041,Marin,CA,PacificPrevailing
+6043,Mariposa,CA,PacificPrevailing
+6045,Mendocino,CA,PacificPrevailing
+6047,Merced,CA,PacificPrevailing
+6049,Modoc,CA,PacificPrevailing
+6051,Mono,CA,PacificPrevailing
+6053,Monterey,CA,PacificPrevailing
+6055,Napa,CA,PacificPrevailing
+6057,Nevada,CA,PacificPrevailing
+6059,Orange,CA,PacificPrevailing
+6061,Placer,CA,PacificPrevailing
+6063,Plumas,CA,PacificPrevailing
+6065,Riverside,CA,PacificPrevailing
+6067,Sacramento,CA,PacificPrevailing
+6069,San Benito,CA,PacificPrevailing
+6071,San Bernardino,CA,PacificPrevailing
+6073,San Diego,CA,PacificPrevailing
+6075,San Francisco,CA,PacificPrevailing
+6077,San Joaquin,CA,PacificPrevailing
+6079,San Luis Obispo,CA,PacificPrevailing
+6081,San Mateo,CA,PacificPrevailing
+6083,Santa Barbara,CA,PacificPrevailing
+6085,Santa Clara,CA,PacificPrevailing
+6087,Santa Cruz,CA,PacificPrevailing
+6089,Shasta,CA,PacificPrevailing
+6091,Sierra,CA,PacificPrevailing
+6093,Siskiyou,CA,PacificPrevailing
+6095,Solano,CA,PacificPrevailing
+6097,Sonoma,CA,PacificPrevailing
+6099,Stanislaus,CA,PacificPrevailing
+6101,Sutter,CA,PacificPrevailing
+6103,Tehama,CA,PacificPrevailing
+6105,Trinity,CA,PacificPrevailing
+6107,Tulare,CA,PacificPrevailing
+6109,Tuolumne,CA,PacificPrevailing
+6111,Ventura,CA,PacificPrevailing
+6113,Yolo,CA,PacificPrevailing
+6115,Yuba,CA,PacificPrevailing
+8001,Adams,CO,MountainPrevailing
+8003,Alamosa,CO,MountainPrevailing
+8005,Arapahoe,CO,MountainPrevailing
+8007,Archuleta,CO,MountainPrevailing
+8009,Baca,CO,MountainPrevailing
+8011,Bent,CO,MountainPrevailing
+8013,Boulder,CO,MountainPrevailing
+8014,Broomfield,CO,MountainPrevailing
+8015,Chaffee,CO,MountainPrevailing
+8017,Cheyenne,CO,MountainPrevailing
+8019,Clear Creek,CO,MountainPrevailing
+8021,Conejos,CO,MountainPrevailing
+8023,Costilla,CO,MountainPrevailing
+8025,Crowley,CO,MountainPrevailing
+8027,Custer,CO,MountainPrevailing
+8029,Delta,CO,MountainPrevailing
+8031,Denver,CO,MountainPrevailing
+8033,Dolores,CO,MountainPrevailing
+8035,Douglas,CO,MountainPrevailing
+8037,Eagle,CO,MountainPrevailing
+8039,Elbert,CO,MountainPrevailing
+8041,El Paso,CO,MountainPrevailing
+8043,Fremont,CO,MountainPrevailing
+8045,Garfield,CO,MountainPrevailing
+8047,Gilpin,CO,MountainPrevailing
+8049,Grand,CO,MountainPrevailing
+8051,Gunnison,CO,MountainPrevailing
+8053,Hinsdale,CO,MountainPrevailing
+8055,Huerfano,CO,MountainPrevailing
+8057,Jackson,CO,MountainPrevailing
+8059,Jefferson,CO,MountainPrevailing
+8061,Kiowa,CO,MountainPrevailing
+8063,Kit Carson,CO,MountainPrevailing
+8065,Lake,CO,MountainPrevailing
+8067,La Plata,CO,MountainPrevailing
+8069,Larimer,CO,MountainPrevailing
+8071,Las Animas,CO,MountainPrevailing
+8073,Lincoln,CO,MountainPrevailing
+8075,Logan,CO,MountainPrevailing
+8077,Mesa,CO,MountainPrevailing
+8079,Mineral,CO,MountainPrevailing
+8081,Moffat,CO,MountainPrevailing
+8083,Montezuma,CO,MountainPrevailing
+8085,Montrose,CO,MountainPrevailing
+8087,Morgan,CO,MountainPrevailing
+8089,Otero,CO,MountainPrevailing
+8091,Ouray,CO,MountainPrevailing
+8093,Park,CO,MountainPrevailing
+8095,Phillips,CO,MountainPrevailing
+8097,Pitkin,CO,MountainPrevailing
+8099,Prowers,CO,MountainPrevailing
+8101,Pueblo,CO,MountainPrevailing
+8103,Rio Blanco,CO,MountainPrevailing
+8105,Rio Grande,CO,MountainPrevailing
+8107,Routt,CO,MountainPrevailing
+8109,Saguache,CO,MountainPrevailing
+8111,San Juan,CO,MountainPrevailing
+8113,San Miguel,CO,MountainPrevailing
+8115,Sedgwick,CO,MountainPrevailing
+8117,Summit,CO,MountainPrevailing
+8119,Teller,CO,MountainPrevailing
+8121,Washington,CO,MountainPrevailing
+8123,Weld,CO,MountainPrevailing
+8125,Yuma,CO,MountainPrevailing
+9001,Fairfield,CT,EasternPrevailing
+9003,Hartford,CT,EasternPrevailing
+9005,Litchfield,CT,EasternPrevailing
+9007,Middlesex,CT,EasternPrevailing
+9009,New Haven,CT,EasternPrevailing
+9011,New London,CT,EasternPrevailing
+9013,Tolland,CT,EasternPrevailing
+9015,Windham,CT,EasternPrevailing
 10001,Kent,DE,EasternPrevailing
 10003,New Castle,DE,EasternPrevailing
 10005,Sussex,DE,EasternPrevailing
@@ -1767,7 +1767,7 @@ id,name,state,time_zone
 35007,Colfax,NM,MountainPrevailing
 35009,Curry,NM,MountainPrevailing
 35011,De Baca,NM,MountainPrevailing
-35013,Do?a Ana,NM,MountainPrevailing
+35013,Dona Ana,NM,MountainPrevailing
 35015,Eddy,NM,MountainPrevailing
 35017,Grant,NM,MountainPrevailing
 35019,Guadalupe,NM,MountainPrevailing


### PR DESCRIPTION
Fix time zone mapping in county files:
- dsgrid-project-StandardScenarios/dsgrid_project/dimensions/counties.csv
- dsgrid-project-StandardScenarios/tempo_project/dimensions/counties.csv
- dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/resstock/dimensions/conus_2022-resstock_geography_county_fips.csv
- dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/comstock/dimensions/conus_2022-comstock_geography_county_fips.csv
- dsgrid-project-DECARB/project/dimensions/counties.csv

Time zones affected:
[1] AZ counties except Navajo now gets "USArizona" (introduced in [dsgrid PR](https://github.com/dsgrid/dsgrid/pull/296) to use time functions like .get_prevailing_time(), .is_standard()) instead of "MountainStandard". These counties only have a name change for their timezones and are not affected.
```
         id           name state      old_time_zone           time_zone
67     4001         Apache    AZ   MountainStandard           USArizona
68     4003        Cochise    AZ   MountainStandard           USArizona
69     4005       Coconino    AZ   MountainStandard           USArizona
70     4007           Gila    AZ   MountainStandard           USArizona
71     4009         Graham    AZ   MountainStandard           USArizona
72     4011       Greenlee    AZ   MountainStandard           USArizona
73     4012         La Paz    AZ   MountainStandard           USArizona
74     4013       Maricopa    AZ   MountainStandard           USArizona
75     4015         Mohave    AZ   MountainStandard           USArizona
77     4019           Pima    AZ   MountainStandard           USArizona
78     4021          Pinal    AZ   MountainStandard           USArizona
79     4023     Santa Cruz    AZ   MountainStandard           USArizona
80     4025        Yavapai    AZ   MountainStandard           USArizona
81     4027           Yuma    AZ   MountainStandard           USArizona
```
[2] These counties had incorrect time zones previously:
```
         id           name state      old_time_zone           time_zone
1982  38053       McKenzie    ND  CentralPrevailing  MountainPrevailing
2330  46007        Bennett    SD  EasternPrevailing  MountainPrevailing
2336  46019          Butte    SD  EasternPrevailing  MountainPrevailing
2342  46031         Corson    SD  EasternPrevailing  MountainPrevailing
2343  46033         Custer    SD  EasternPrevailing  MountainPrevailing
2347  46041          Dewey    SD  EasternPrevailing  MountainPrevailing
2350  46047     Fall River    SD  EasternPrevailing  MountainPrevailing
2354  46055         Haakon    SD  EasternPrevailing  MountainPrevailing
2358  46063        Harding    SD  EasternPrevailing  MountainPrevailing
2362  46071        Jackson    SD  EasternPrevailing  MountainPrevailing
2367  46081       Lawrence    SD  EasternPrevailing  MountainPrevailing
2373  46093          Meade    SD  EasternPrevailing  MountainPrevailing
```